### PR TITLE
VRMUnlitTexture / VRMUnlitCutout shader

### DIFF
--- a/Resources/Shaders/VRMUnlitCutout.shader
+++ b/Resources/Shaders/VRMUnlitCutout.shader
@@ -52,6 +52,7 @@ SubShader {
 				fixed4 col = tex2D(_MainTex, i.texcoord);
 				clip(col.a - _Cutoff);
 				UNITY_APPLY_FOG(i.fogCoord, col);
+				UNITY_OPAQUE_ALPHA(col.a);
 				return col;
 			}
 		ENDCG

--- a/Resources/Shaders/VRMUnlitTexture.shader
+++ b/Resources/Shaders/VRMUnlitTexture.shader
@@ -50,6 +50,7 @@
 				fixed4 col = tex2D(_MainTex, i.uv);
 				// apply fog
 				UNITY_APPLY_FOG(i.fogCoord, col);
+				UNITY_OPAQUE_ALPHA(col.a);
 				return col;
 			}
 			ENDCG


### PR DESCRIPTION
https://github.com/dwango/UniVRM/issues/28 に関連して、MToonの修正をありがとうございます。

ですが[公開されているニコニ立体ちゃんVRMモデル](http://3d.nicovideo.jp/works/td32797 )では不自然な透明がまだ解決していないため、Unityのビルトインシェーダー（[パッチ 5.6.0p1 のもの](https://beta.unity3d.com/download/6c0210300415/builtin_shaders-5.6.0p1.zip?_ga=2.106665539.159543226.1535847772-706988445.1516599728)で確認）
* Unlit-Normal.shader
* Unlit-Color.shader
などと同様に、`UNITY_OPAQUE_ALPHA(col.a);` を追記してもよいかと考えます。