### PR TITLE
Optimize comparing struct in dictionary key

### DIFF
--- a/Scripts/BlendShape/BlendShapeBindingMerger.cs
+++ b/Scripts/BlendShape/BlendShapeBindingMerger.cs
@@ -9,7 +9,7 @@ namespace VRM
     ///
     class BlendShapeBindingMerger
     {
-        class BlendShapeBindingComparer : IEqualityComparer<BlendShapeBinding>
+        class DictionaryKeyBlendShapeBindingComparer : IEqualityComparer<BlendShapeBinding>
         {
             public bool Equals(BlendShapeBinding x, BlendShapeBinding y)
             {
@@ -22,19 +22,22 @@ namespace VRM
                 return obj.RelativePath.GetHashCode() + obj.Index;
             }
         }
+        
+        private static DictionaryKeyBlendShapeBindingComparer comparer = new DictionaryKeyBlendShapeBindingComparer();
+
         /// <summary>
         /// BlendShapeの適用値を蓄積する
         /// </summary>
         /// <typeparam name="BlendShapeBinding"></typeparam>
         /// <typeparam name="float"></typeparam>
         /// <returns></returns>
-        Dictionary<BlendShapeBinding, float> m_blendShapeValueMap = new Dictionary<BlendShapeBinding, float>(new BlendShapeBindingComparer());
+        Dictionary<BlendShapeBinding, float> m_blendShapeValueMap = new Dictionary<BlendShapeBinding, float>(comparer);
 
         /// <summary>
         /// 
         /// </summary>
         /// <returns></returns>
-        Dictionary<BlendShapeBinding, Action<float>> m_blendShapeSetterMap = new Dictionary<BlendShapeBinding, Action<float>>();
+        Dictionary<BlendShapeBinding, Action<float>> m_blendShapeSetterMap = new Dictionary<BlendShapeBinding, Action<float>>(comparer);
 
         public BlendShapeBindingMerger(Dictionary<BlendShapeKey, BlendShapeClip> clipMap, Transform root)
         {

--- a/Scripts/BlendShape/BlendShapeClip.cs
+++ b/Scripts/BlendShape/BlendShapeClip.cs
@@ -4,8 +4,8 @@ using UnityEngine;
 
 namespace VRM
 {
-    [Serializable]
-    public struct BlendShapeBinding
+   [Serializable]
+    public struct BlendShapeBinding : IEquatable<BlendShapeBinding>
     {
         public String RelativePath;
         public int Index;
@@ -15,15 +15,60 @@ namespace VRM
         {
             return string.Format("{0}[{1}]=>{2}", RelativePath, Index, Weight);
         }
+
+        public bool Equals(BlendShapeBinding other)
+        {
+            return string.Equals(RelativePath, other.RelativePath) && Index == other.Index && Weight.Equals(other.Weight);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            return obj is BlendShapeBinding && Equals((BlendShapeBinding)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (RelativePath != null ? RelativePath.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ Index;
+                hashCode = (hashCode * 397) ^ Weight.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 
     [Serializable]
-    public struct MaterialValueBinding
+    public struct MaterialValueBinding : IEquatable<MaterialValueBinding>
     {
         public String MaterialName;
         public String ValueName;
         public Vector4 TargetValue;
         public Vector4 BaseValue;
+
+        public bool Equals(MaterialValueBinding other)
+        {
+            return string.Equals(MaterialName, other.MaterialName) && string.Equals(ValueName, other.ValueName) && TargetValue.Equals(other.TargetValue) && BaseValue.Equals(other.BaseValue);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            return obj is MaterialValueBinding && Equals((MaterialValueBinding)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (MaterialName != null ? MaterialName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (ValueName != null ? ValueName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ TargetValue.GetHashCode();
+                hashCode = (hashCode * 397) ^ BaseValue.GetHashCode();
+                return hashCode;
+            }
+        }
     }
 
     [CreateAssetMenu(menuName = "VRM/BlendShapeClip")]

--- a/Scripts/BlendShape/MaterialValueBindingMerger.cs
+++ b/Scripts/BlendShape/MaterialValueBindingMerger.cs
@@ -11,6 +11,22 @@ namespace VRM
     ///
     class MaterialValueBindingMerger
     {
+
+        struct DictionaryKeyMaterialValueBindingComparer : IEqualityComparer<MaterialValueBinding>
+        {
+            public bool Equals(MaterialValueBinding x, MaterialValueBinding y)
+            {
+                return x.TargetValue == y.TargetValue && x.BaseValue == y.BaseValue && x.MaterialName == y.MaterialName && x.ValueName == y.ValueName;
+            }
+
+            public int GetHashCode(MaterialValueBinding obj)
+            {
+                return obj.GetHashCode();
+            }
+        }
+
+        static DictionaryKeyMaterialValueBindingComparer comparer = new DictionaryKeyMaterialValueBindingComparer();
+
         /// <summary>
         /// 名前とmaterialのマッピング
         /// </summary>
@@ -24,9 +40,9 @@ namespace VRM
         /// <typeparam name="MaterialValueBinding"></typeparam>
         /// <typeparam name="float"></typeparam>
         /// <returns></returns>
-        Dictionary<MaterialValueBinding, float> m_materialValueMap = new Dictionary<MaterialValueBinding, float>();
+        Dictionary<MaterialValueBinding, float> m_materialValueMap = new Dictionary<MaterialValueBinding, float>(comparer);
 
-        Dictionary<MaterialValueBinding, Setter> m_materialSetterMap = new Dictionary<MaterialValueBinding, Setter>();
+        Dictionary<MaterialValueBinding, Setter> m_materialSetterMap = new Dictionary<MaterialValueBinding, Setter>(comparer);
 
         //BlendShapeClip[] m_clips;
 


### PR DESCRIPTION
BlendShape変更時にDictonaryのKey比較でBox化が発生していたため、それを回避するようにしました。