### PR TITLE
Round glTF2.0 materials[].emissiveFactor value to its maximum limit

### DIFF
--- a/Assets/VRM/UniGLTF/Editor/MaterialTests.cs
+++ b/Assets/VRM/UniGLTF/Editor/MaterialTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using UnityEngine;
 
 
 namespace UniGLTF
@@ -175,6 +176,18 @@ namespace UniGLTF
                 });
                 Assert.AreEqual("Standard", material.shader.name);
             }
+        }
+
+        [Test]
+        public void MaterialExportTest()
+        {
+            var material = new Material(Shader.Find("Standard"));
+            material.SetColor("_EmissionColor", new Color(0, 1, 2, 1));
+            var materialExporter = new MaterialExporter();
+            var textureExportManager = new TextureExportManager(new Texture[] { });
+            var gltfMaterial = materialExporter.ExportMaterial(material, textureExportManager);
+
+            Assert.AreEqual(gltfMaterial.emissiveFactor, new float[] { 0, 0.5f, 1 });
         }
     }
 }

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
@@ -135,6 +135,10 @@ namespace UniGLTF
             if (m.HasProperty("_EmissionColor"))
             {
                 var color = m.GetColor("_EmissionColor");
+                if (color.maxColorComponent > 1)
+                {
+                    color /= color.maxColorComponent;
+                }
                 material.emissiveFactor = new float[] { color.r, color.g, color.b };
             }
 


### PR DESCRIPTION
[glTF2.0の仕様によると](https://github.com/KhronosGroup/glTF/tree/3ddfeefd42b47ba615ff57bcba3191f9b7e4cf92/specification/2.0#materialemissivefactor)、 `jsonのmaterials[].emissiveFactor` の最大値は `1` になっていますが、UnityエディタのマテリアルのInspectorからEmissionを有効にしColorのIntensityを増やすと、glbのエクスポート時に当該の値が `1` を超えてエラーになってしまうことがあります。

そのような場合に `1` を超えないようにcolorの値を調整するようにしました。当該の値はglbフォールバック用の値として設定されるもので、VRMのエクステンション側にオリジナルの値が残っているとのことなので、値を勝手に調整してしまっても安全であるという判断です。


`materials[].emissiveFactor` の最大値を増加させる提案はこちらのIssue https://github.com/KhronosGroup/glTF/issues/1083 でkhronosの方に出ていますが、すぐには採用されなそうな雰囲気です。

変更前、変更後でそれぞれで [glbのサンプルファイル](https://github.com/KhronosGroup/glTF-Sample-Models/blob/2262917421f9b7acdf159350a8247afd11f74343/2.0/Box/glTF-Binary/Box.glb) をインポート、マテリアルの Emission Color を `#00BF00` に、Intensityを `1` に設定しエクスポートしたものを[glTF Validator](https://github.khronos.org/glTF-Validator/)にかけた結果が下記になります


| 変更前 | 変更後 |
| --- | --- |
| ![before3](https://user-images.githubusercontent.com/532872/50550018-320a7d80-0cab-11e9-9e7b-1a92cc0b6ac0.png) | ![after3](https://user-images.githubusercontent.com/532872/50550019-359e0480-0cab-11e9-835f-7cfdc0d96f78.png) |

変更前、変更後共に下記の設定でエクスポートしています

![config](https://user-images.githubusercontent.com/532872/50549894-9972fe00-0ca8-11e9-92cd-6e8db1ca5e56.png)
