### PR TITLE
Remove invalid json like `meshes[].primitives[].targets[].TANGENT = -1`

### DIFF
--- a/Assets/VRM/UniGLTF/Editor/UniGLTFTests.cs
+++ b/Assets/VRM/UniGLTF/Editor/UniGLTFTests.cs
@@ -191,5 +191,81 @@ namespace UniGLTF
             Debug.Log(json);
         }
 
+        [Test]
+        public void GlTFToJsonTest()
+        {
+            var gltf = new glTF();
+            using (var exporter = new gltfExporter(gltf))
+            {
+                exporter.Prepare(CreateSimpleScene());
+                exporter.Export();
+            }
+
+            var expected = gltf.ToJson().ParseAsJson();
+            expected.AddKey(Utf8String.From("meshes"));
+            expected.AddValue(default(ArraySegment<byte>), ValueNodeType.Array);
+            expected["meshes"].AddValue(default(ArraySegment<byte>), ValueNodeType.Object);
+
+            var mesh = expected["meshes"][0];
+            mesh.AddKey(Utf8String.From("name"));
+            mesh.AddValue(Utf8String.From(JsonString.Quote("test")).Bytes, ValueNodeType.String);
+            mesh.AddKey(Utf8String.From("primitives"));
+            mesh.AddValue(default(ArraySegment<byte>), ValueNodeType.Array);
+            mesh["primitives"].AddValue(default(ArraySegment<byte>), ValueNodeType.Object);
+
+            var primitive = mesh["primitives"][0];
+            primitive.AddKey(Utf8String.From("mode"));
+            primitive.AddValue(Utf8String.From("0").Bytes, ValueNodeType.Integer);
+            primitive.AddKey(Utf8String.From("indices"));
+            primitive.AddValue(Utf8String.From("0").Bytes, ValueNodeType.Integer);
+            primitive.AddKey(Utf8String.From("material"));
+            primitive.AddValue(Utf8String.From("0").Bytes, ValueNodeType.Integer);
+            primitive.AddKey(Utf8String.From("attributes"));
+            primitive.AddValue(default(ArraySegment<byte>), ValueNodeType.Object);
+            primitive["attributes"].AddKey(Utf8String.From("POSITION"));
+            primitive["attributes"].AddValue(Utf8String.From("0").Bytes, ValueNodeType.Integer);
+            primitive.AddKey(Utf8String.From("targets"));
+            primitive.AddValue(default(ArraySegment<byte>), ValueNodeType.Array);
+            primitive["targets"].AddValue(default(ArraySegment<byte>), ValueNodeType.Object);
+            primitive["targets"][0].AddKey(Utf8String.From("POSITION"));
+            primitive["targets"][0].AddValue(Utf8String.From("1").Bytes, ValueNodeType.Integer);
+            primitive["targets"].AddValue(default(ArraySegment<byte>), ValueNodeType.Object);
+            primitive["targets"][1].AddKey(Utf8String.From("POSITION"));
+            primitive["targets"][1].AddValue(Utf8String.From("2").Bytes, ValueNodeType.Integer);
+            primitive["targets"][1].AddKey(Utf8String.From("TANGENT"));
+            primitive["targets"][1].AddValue(Utf8String.From("0").Bytes, ValueNodeType.Integer);
+
+            gltf.meshes.Add(new glTFMesh("test")
+            {
+                primitives = new List<glTFPrimitives>
+                {
+                    new glTFPrimitives
+                    {
+                        indices = 0,
+                        attributes = new glTFAttributes
+                        {
+                            POSITION = 0,
+                            TANGENT = -1 // should be removed
+                        },
+                        targets = new List<gltfMorphTarget>
+                        {
+                            new gltfMorphTarget
+                            {
+                                POSITION = 1,
+                                TANGENT = -1 // should be removed
+                            },
+                            new gltfMorphTarget
+                            {
+                                POSITION = 2,
+                                TANGENT = 0
+                            }
+                        }
+                    }
+                }
+            });
+            var actual = gltf.ToJson().ParseAsJson();
+
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/Assets/VRM/UniGLTF/Scripts/Format/ExtensionsAndExtras/KHR_materials_unlit.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/ExtensionsAndExtras/KHR_materials_unlit.cs
@@ -48,7 +48,7 @@ namespace UniGLTF
         {
             if (KHR_materials_unlit != null)
             {
-                f.KeyValue(() => KHR_materials_unlit);
+                f.Key("KHR_materials_unlit"); f.GLTFValue(KHR_materials_unlit);
             }
         }
     }

--- a/Assets/VRM/UniGLTF/Scripts/Format/glTF.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTF.cs
@@ -345,23 +345,23 @@ namespace UniGLTF
         {
             if (extensionsUsed.Count > 0)
             {
-                f.KeyValue(() => extensionsUsed);
+                f.Key("extensionsUsed"); f.GLTFValue(extensionsUsed);
             }
             if (extensions.__count > 0)
             {
-                f.KeyValue(() => extensions);
+                f.Key("extensions"); f.GLTFValue(extensions);
             }
             if (extras.__count > 0)
             {
-                f.KeyValue(() => extras);
+                f.Key("extras"); f.GLTFValue(extras);
             }
 
-            f.KeyValue(() => asset);
+            f.Key("asset"); f.GLTFValue(asset);
 
             // buffer
             if (buffers.Any())
             {
-                f.KeyValue(() => buffers);
+                f.Key("buffers"); f.GLTFValue(buffers);
             }
             if (bufferViews.Any())
             {
@@ -399,21 +399,21 @@ namespace UniGLTF
             // meshes
             if (meshes.Any())
             {
-                f.KeyValue(() => meshes);
+                f.Key("meshes"); f.GLTFValue(meshes);
             }
             if (skins.Any())
             {
-                f.KeyValue(() => skins);
+                f.Key("skins"); f.GLTFValue(skins);
             }
 
             // scene
             if (nodes.Any())
             {
-                f.KeyValue(() => nodes);
+                f.Key("nodes"); f.GLTFValue(nodes);
             }
             if (scenes.Any())
             {
-                f.KeyValue(() => scenes);
+                f.Key("scenes"); f.GLTFValue(scenes);
                 if (scene >= 0)
                 {
                     f.KeyValue(() => scene);

--- a/Assets/VRM/UniGLTF/Scripts/Format/glTFAnimation.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTFAnimation.cs
@@ -122,7 +122,7 @@ namespace UniGLTF
         protected override void SerializeMembers(GLTFJsonFormatter f)
         {
             f.KeyValue(() => sampler);
-            f.KeyValue(() => target);
+            f.Key("target"); f.GLTFValue(target);
         }
     }
 
@@ -175,8 +175,8 @@ namespace UniGLTF
                 f.KeyValue(() => name);
             }
 
-            f.KeyValue(() => channels);
-            f.KeyValue(() => samplers);
+            f.Key("channels"); f.GLTFValue(channels);
+            f.Key("samplers"); f.GLTFValue(samplers);
         }
 
         public int AddChannelAndGetSampler(int nodeIndex, glTFAnimationTarget.AnimationPropertys property)

--- a/Assets/VRM/UniGLTF/Scripts/Format/glTFBuffer.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTFBuffer.cs
@@ -169,8 +169,8 @@ namespace UniGLTF
         protected override void SerializeMembers(GLTFJsonFormatter f)
         {
             f.KeyValue(() => count);
-            f.KeyValue(() => indices);
-            f.KeyValue(() => values);
+            f.Key("indices"); f.GLTFValue(indices);
+            f.Key("values"); f.GLTFValue(values);
         }
     }
 
@@ -251,7 +251,7 @@ namespace UniGLTF
 
             if (sparse != null && sparse.count > 0)
             {
-                f.KeyValue(() => sparse);
+                f.Key("sparse"); f.GLTFValue(sparse);
             }
 
             f.KeyValue(() => normalized);

--- a/Assets/VRM/UniGLTF/Scripts/Format/glTFMaterial.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTFMaterial.cs
@@ -128,7 +128,7 @@ namespace UniGLTF
         {
             if (baseColorTexture != null)
             {
-                f.KeyValue(() => baseColorTexture);
+                f.Key("baseColorTexture"); f.GLTFValue(baseColorTexture);
             }
             if (baseColorFactor != null)
             {
@@ -136,7 +136,7 @@ namespace UniGLTF
             }
             if (metallicRoughnessTexture != null)
             {
-                f.KeyValue(() => metallicRoughnessTexture);
+                f.Key("metallicRoughnessTexture"); f.GLTFValue(metallicRoughnessTexture);
             }
             f.KeyValue(() => metallicFactor);
             f.KeyValue(() => roughnessFactor);
@@ -206,7 +206,7 @@ namespace UniGLTF
 
             if (extensions != null)
             {
-                f.KeyValue(() => extensions);
+                f.Key("extensions"); f.GLTFValue(extensions);
             }
         }
 

--- a/Assets/VRM/UniGLTF/Scripts/Format/glTFMesh.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTFMesh.cs
@@ -125,11 +125,11 @@ namespace UniGLTF
             }
             if (extensions.KHR_draco_mesh_compression != null)
             {
-                f.KeyValue(() => extensions);
+                f.Key("extensions"); f.GLTFValue(extensions);
             }
             if (extras.targetNames.Count > 0)
             {
-                f.KeyValue(() => extras);
+                f.Key("extras"); f.GLTFValue(extras);
             }
         }
     }

--- a/Assets/VRM/UniGLTF/Scripts/Format/glTFNode.cs
+++ b/Assets/VRM/UniGLTF/Scripts/Format/glTFNode.cs
@@ -68,7 +68,7 @@ namespace UniGLTF
 
                 if (extras.__count > 0)
                 {
-                    f.KeyValue(() => extras);
+                    f.Key("extras"); f.GLTFValue(extras);
                 }
             }
         }

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMFormat.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMFormat.cs
@@ -12,7 +12,7 @@ namespace UniGLTF
         [JsonSerializeMembers]
         void VRMSerializeMembers(GLTFJsonFormatter f)
         {
-            f.KeyValue(() => VRM);
+            f.Key("VRM"); f.GLTFValue(VRM);
         }
     }
 }
@@ -47,12 +47,12 @@ VRM extension is for 3d humanoid avatars (and models) in VR applications.
         protected override void SerializeMembers(GLTFJsonFormatter f)
         {
             f.KeyValue(() => exporterVersion);
-            f.KeyValue(() => meta);
-            f.KeyValue(() => humanoid);
-            f.KeyValue(() => firstPerson);
-            f.KeyValue(() => blendShapeMaster);
-            f.KeyValue(() => secondaryAnimation);
-            f.KeyValue(() => materialProperties);
+            f.Key("meta"); f.GLTFValue(meta);
+            f.Key("humanoid"); f.GLTFValue(humanoid);
+            f.Key("firstPerson"); f.GLTFValue(firstPerson);
+            f.Key("blendShapeMaster"); f.GLTFValue(blendShapeMaster);
+            f.Key("secondaryAnimation"); f.GLTFValue(secondaryAnimation);
+            f.Key("materialProperties"); f.GLTFValue(materialProperties);
         }
     }
 }

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_BlendShape.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_BlendShape.cs
@@ -132,8 +132,8 @@ namespace VRM
             f.KeyValue(() => name);
             f.KeyValue(() => presetName);
             f.KeyValue(() => isBinary);
-            f.KeyValue(() => binds);
-            f.KeyValue(() => materialValues);
+            f.Key("binds"); f.GLTFValue(binds);
+            f.Key("materialValues"); f.GLTFValue(materialValues);
         }
     }
 
@@ -175,7 +175,7 @@ namespace VRM
 
         protected override void SerializeMembers(GLTFJsonFormatter f)
         {
-            f.KeyValue(() => blendShapeGroups);
+            f.Key("blendShapeGroups"); f.GLTFValue(blendShapeGroups);
         }
     }
 }

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_FirstPerson.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_FirstPerson.cs
@@ -112,13 +112,13 @@ namespace VRM
         {
             f.KeyValue(() => firstPersonBone);
             f.KeyValue(() => firstPersonBoneOffset);
-            f.KeyValue(() => meshAnnotations);
+            f.Key("meshAnnotations"); f.GLTFValue(meshAnnotations);
 
             f.KeyValue(() => lookAtTypeName);
-            f.KeyValue(() => lookAtHorizontalInner);
-            f.KeyValue(() => lookAtHorizontalOuter);
-            f.KeyValue(() => lookAtVerticalDown);
-            f.KeyValue(() => lookAtVerticalUp);
+            f.Key("lookAtHorizontalInner"); f.GLTFValue(lookAtHorizontalInner);
+            f.Key("lookAtHorizontalOuter"); f.GLTFValue(lookAtHorizontalOuter);
+            f.Key("lookAtVerticalDown"); f.GLTFValue(lookAtVerticalDown);
+            f.Key("lookAtVerticalUp"); f.GLTFValue(lookAtVerticalUp);
         }
     }
 }

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Humanoid.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Humanoid.cs
@@ -246,7 +246,7 @@ namespace VRM
 
         protected override void SerializeMembers(GLTFJsonFormatter f)
         {
-            f.KeyValue(() => humanBones);
+            f.Key("humanBones"); f.GLTFValue(humanBones);
             f.KeyValue(() => armStretch);
             f.KeyValue(() => legStretch);
             f.KeyValue(() => upperArmTwist);

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_SecondaryAnimation.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_SecondaryAnimation.cs
@@ -36,7 +36,7 @@ namespace VRM
         protected override void SerializeMembers(GLTFJsonFormatter f)
         {
             f.KeyValue(() => node);
-            f.KeyValue(() => colliders);
+            f.Key("colliders"); f.GLTFValue(colliders);
         }
     }
 
@@ -95,8 +95,8 @@ namespace VRM
 
         protected override void SerializeMembers(GLTFJsonFormatter f)
         {
-            f.KeyValue(() => boneGroups);
-            f.KeyValue(() => colliderGroups);
+            f.Key("boneGroups"); f.GLTFValue(boneGroups);
+            f.Key("colliderGroups"); f.GLTFValue(colliderGroups);
         }
     }
 }


### PR DESCRIPTION
In UniVRM v0.45 invalid glTF json values like
`meshes[].primitives[].targets[].TANGENT = -1` had been removed
by UniGLTF.JsonSerializableBase.SerializeMembers(). But it was disabled
unexpectedly since v0.46's following commit:
https://github.com/ousttrue/UniGLTF/commit/a85b9699e76fb88e279330182ae9972062a4f5d6#diff-6d81c3ba04eb19e159e64767f9dd1325L36

Now call UniGLTF.GLTFJsonFormatter.GLTFValue() explicitly to run serializable's
SerializeMembers() for removing those values that restores UniVRM v0.45
behavior without reflections.

Fixes #105

[glTF Validator](https://github.khronos.org/glTF-Validator/)'s result for [Alicia Solid Model 0.40](https://github.com/dwango/UniVRMTest/blob/fbbaf6fe2baf6009aa425fae6afe4f3f7d1f6486/Models/Alicia_vrm-0.40/AliciaSolid_vrm-0.40.vrm)

| Current master https://github.com/dwango/UniVRM/commit/6ae89549b500589954da9168860e25ad4b5d4bb6 | Fixed by https://github.com/dwango/UniVRM/pull/110 |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/532872/50657159-f6d4bb00-0fd8-11e9-902c-f6570567e078.png) | ![after](https://user-images.githubusercontent.com/532872/50657173-005e2300-0fd9-11e9-95d3-bb11d5e32329.png) |
