### PR TITLE
 Throw exception on serialize 32bit time older than unix epoch

### DIFF
--- a/Assets/VRM/UniJSON/Scripts/Extensions/DateTimeOffsetExtensions.cs
+++ b/Assets/VRM/UniJSON/Scripts/Extensions/DateTimeOffsetExtensions.cs
@@ -6,15 +6,17 @@ namespace UniJSON
     public static class DateTimeOffsetExtensions
     {
         public const long TicksPerSecond = 10000000;
-        public readonly static DateTimeOffset EpocTime = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+        public readonly static DateTimeOffset EpochTime = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+        [Obsolete("Use EpochTime")]
+        public readonly static DateTimeOffset EpocTime = EpochTime;
 #if !NET_4_6 && !NET_STANDARD_2_0
         public static long ToUnixTimeSeconds(this DateTimeOffset now)
         {
-            if (now < EpocTime)
+            if (now < EpochTime)
             {
                 throw new ArgumentOutOfRangeException();
             }
-            return (now - EpocTime).Ticks / TicksPerSecond;
+            return (now - EpochTime).Ticks / TicksPerSecond;
         }
 #endif
     }

--- a/Assets/VRM/UniJSON/Scripts/MsgPack/MsgPackFormatter.cs
+++ b/Assets/VRM/UniJSON/Scripts/MsgPack/MsgPackFormatter.cs
@@ -418,6 +418,11 @@ namespace UniJSON
 
         public void TimeStamp32(DateTimeOffset time)
         {
+            // https://github.com/ousttrue/UniJSON/blob/1.2/Scripts/Extensions/DateTimeOffsetExtensions.cs#L13-L16
+            if (time < DateTimeOffsetExtensions.EpochTime)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
             m_store.Write((Byte)MsgPackType.FIX_EXT_4);
             m_store.Write((SByte)(-1));
             m_store.WriteBigEndian((uint)time.ToUnixTimeSeconds());

--- a/Assets/VRM/UniJSON/Scripts/MsgPack/MsgPackValue.cs
+++ b/Assets/VRM/UniJSON/Scripts/MsgPack/MsgPackValue.cs
@@ -631,7 +631,7 @@ namespace UniJSON
                         if (GetExtType() == -1)
                         {
                             var unixtime = EndianConverter.NetworkByteDWordToUnsignedNativeByteOrder(GetBody());
-                            var dt = new DateTimeOffset(unixtime * DateTimeOffsetExtensions.TicksPerSecond + DateTimeOffsetExtensions.EpocTime.Ticks, TimeSpan.Zero);
+                            var dt = new DateTimeOffset(unixtime * DateTimeOffsetExtensions.TicksPerSecond + DateTimeOffsetExtensions.EpochTime.Ticks, TimeSpan.Zero);
                             return GenericCast<DateTimeOffset, T>.Cast(dt);
                         }
                         break;


### PR DESCRIPTION
.NET 4.6やStandard 2.0で、MsgPackへ32ビットタイムスタンプとして古すぎる値を入れたときに失敗することを確認するテストが落ちていたのを修正しました。

Typoの修正 https://github.com/dwango/UniVRM/pull/117 適用後に確認お願いします。