### PR TITLE
add execution order number (avoid order conflict with vrik)

### DIFF
--- a/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs
+++ b/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs
@@ -7,7 +7,11 @@ namespace VRM
 {
     /// <summary>
     /// The base algorithm is http://rocketjump.skr.jp/unity3d/109/ of @ricopin416
+    /// DefaultExecutionOrder(11000) means calclate springbone after FinaiIK( VRIK )
     /// </summary>
+    #if UNITY_5_5_OR_NEWER
+    [DefaultExecutionOrder(11000)]
+    #endif
     public class VRMSpringBone : MonoBehaviour
     {
         [SerializeField]

--- a/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBoneColliderGroup.cs
+++ b/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBoneColliderGroup.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 namespace VRM
 {
+    #if UNITY_5_5_OR_NEWER
+    [DefaultExecutionOrder(11001)]
+    #endif
     public class VRMSpringBoneColliderGroup : MonoBehaviour
     {
         [Serializable]


### PR DESCRIPTION
VRIKやFinalIKとUniVRMを併用するときに、使用者が意識せずともVRMSpringBoneの処理がIK計算の後に行われるようにしておくと、ハマりが減って良いと思います。
現在のアセットストアで入手可能なVRIKおよびFinalIKは <11000のScriptExecutionOrderになっています。
