### PR TITLE
Fix spec for fields which have indices, add minimum=0 for them

### DIFF
--- a/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
@@ -252,6 +252,17 @@ namespace VRM
             Assert.AreEqual(@"{}",json2);
         }
 
+        // TODO: Move to another suitable location
+        [Test]
+        public void MetaDeserializeTest()
+        {
+            var json = @"{}";
+
+            var model = deserialize<glTF_VRM_Meta>(json);
+
+            Assert.AreEqual(-1, model.texture);
+        }
+
         [Test]
         public void SecondaryAnimationColliderTest()
         {
@@ -380,6 +391,12 @@ namespace VRM
             var json2 = JsonSchema.FromType<glTF_VRM_SecondaryAnimation>().Serialize(model, c);
             // NOTE: New serializer outputs values which will not be used...
             Assert.AreEqual(json,json2);
+        }
+
+        // TODO: Move to another suitable location
+        T deserialize<T>(string json)
+        {
+            return JsonUtility.FromJson<T>(json);
         }
     }
 }

--- a/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
@@ -152,7 +152,7 @@ namespace VRM
             };
             var json2 = JsonSchema.FromType<glTF_VRM_Firstperson>().Serialize(model, c);
             Assert.AreEqual(
-                @"{""firstPersonBone"":-1,""firstPersonBoneOffset"":{""x"":0,""y"":0,""z"":0},""meshAnnotations"":[],""lookAtTypeName"":""Bone"",""lookAtHorizontalInner"":{""xRange"":90,""yRange"":10},""lookAtHorizontalOuter"":{""xRange"":90,""yRange"":10},""lookAtVerticalDown"":{""xRange"":90,""yRange"":10},""lookAtVerticalUp"":{""xRange"":90,""yRange"":10}}",
+                @"{""firstPersonBoneOffset"":{""x"":0,""y"":0,""z"":0},""meshAnnotations"":[],""lookAtTypeName"":""Bone"",""lookAtHorizontalInner"":{""xRange"":90,""yRange"":10},""lookAtHorizontalOuter"":{""xRange"":90,""yRange"":10},""lookAtVerticalDown"":{""xRange"":90,""yRange"":10},""lookAtVerticalUp"":{""xRange"":90,""yRange"":10}}",
                 json2);
         }
 
@@ -162,10 +162,11 @@ namespace VRM
             var model = new glTF_VRM_HumanoidBone()
             {
                 bone = "hips", // NOTE: This field must not be null?
+                node = 0,
             };
 
             var json = model.ToJson();
-            Assert.AreEqual(@"{""bone"":""hips"",""node"":-1,""useDefaultValues"":true}", json);
+            Assert.AreEqual(@"{""bone"":""hips"",""node"":0,""useDefaultValues"":true}", json);
             Debug.Log(json);
 
             var c = new JsonSchemaValidationContext("")
@@ -175,8 +176,26 @@ namespace VRM
             var json2 = JsonSchema.FromType<glTF_VRM_HumanoidBone>().Serialize(model, c);
             // NOTE: New serializer outputs values which will not be used...
             Assert.AreEqual(
-                @"{""bone"":""hips"",""node"":-1,""useDefaultValues"":true,""min"":{""x"":0,""y"":0,""z"":0},""max"":{""x"":0,""y"":0,""z"":0},""center"":{""x"":0,""y"":0,""z"":0},""axisLength"":0}",
+                @"{""bone"":""hips"",""node"":0,""useDefaultValues"":true,""min"":{""x"":0,""y"":0,""z"":0},""max"":{""x"":0,""y"":0,""z"":0},""center"":{""x"":0,""y"":0,""z"":0},""axisLength"":0}",
                 json2);
+        }
+
+        [Test]
+        public void HumanoidBoneTestError()
+        {
+            var model = new glTF_VRM_HumanoidBone()
+            {
+                bone = "hips", // NOTE: This field must not be null?
+            };
+
+            var c = new JsonSchemaValidationContext("")
+            {
+                EnableDiagnosisForNotRequiredFields = true,
+            };
+            var ex = Assert.Throws<JsonSchemaValidationException>(
+                () => JsonSchema.FromType<glTF_VRM_HumanoidBone>().Serialize(model, c)
+            );
+            Assert.AreEqual("[node.String] minimum: ! -1>=0", ex.Message);
         }
 
         [Test]
@@ -230,7 +249,7 @@ namespace VRM
             };
             var json2 = JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c);
             // NOTE: New serializer outputs values which will not be used...
-            Assert.AreEqual(json,json2);
+            Assert.AreEqual(@"{}",json2);
         }
 
         [Test]
@@ -274,6 +293,24 @@ namespace VRM
         }
 
         [Test]
+        public void SecondaryAnimationColliderGroupTestError()
+        {
+            var model = new glTF_VRM_SecondaryAnimationColliderGroup()
+            {
+                node = -1,
+            };
+
+            var c = new JsonSchemaValidationContext("")
+            {
+                EnableDiagnosisForNotRequiredFields = true,
+            };
+            var ex = Assert.Throws<JsonSchemaValidationException>(
+                () => JsonSchema.FromType<glTF_VRM_SecondaryAnimationColliderGroup>().Serialize(model, c)
+            );
+            Assert.AreEqual("[node.String] minimum: ! -1>=0", ex.Message);
+        }
+
+        [Test]
         public void SecondaryAnimationGroupTest()
         {
             var model = new glTF_VRM_SecondaryAnimationGroup();
@@ -289,6 +326,42 @@ namespace VRM
             var json2 = JsonSchema.FromType<glTF_VRM_SecondaryAnimationGroup>().Serialize(model, c);
             // NOTE: New serializer outputs values which will not be used...
             Assert.AreEqual(json,json2);
+        }
+
+        [Test]
+        public void SecondaryAnimationGroupTestErrorBones()
+        {
+            var model = new glTF_VRM_SecondaryAnimationGroup()
+            {
+                bones = new int[] { -1 }
+            };
+
+            var c = new JsonSchemaValidationContext("")
+            {
+                EnableDiagnosisForNotRequiredFields = true,
+            };
+            var ex = Assert.Throws<JsonSchemaValidationException>(
+                () => JsonSchema.FromType<glTF_VRM_SecondaryAnimationGroup>().Serialize(model, c)
+            );
+            Assert.AreEqual("[bones.String] minimum: ! -1>=0", ex.Message);
+        }
+
+        [Test]
+        public void SecondaryAnimationGroupTestErrorColliderGroups()
+        {
+            var model = new glTF_VRM_SecondaryAnimationGroup()
+            {
+                colliderGroups = new int[] { -1 }
+            };
+
+            var c = new JsonSchemaValidationContext("")
+            {
+                EnableDiagnosisForNotRequiredFields = true,
+            };
+            var ex = Assert.Throws<JsonSchemaValidationException>(
+                () => JsonSchema.FromType<glTF_VRM_SecondaryAnimationGroup>().Serialize(model, c)
+            );
+            Assert.AreEqual("[colliderGroups.String] minimum: ! -1>=0", ex.Message);
         }
 
         [Test]

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_FirstPerson.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_FirstPerson.cs
@@ -50,6 +50,8 @@ namespace VRM
     [JsonSchema(Title = "vrm.firstperson.meshannotation")]
     public class glTF_VRM_MeshAnnotation : JsonSerializableBase
     {
+        // When the value is -1, it means that no target mesh is found.
+        [JsonSchema(Minimum = 0)]
         public int mesh;
 
         public string firstPersonFlag;
@@ -72,7 +74,8 @@ namespace VRM
     [JsonSchema(Title = "vrm.firstperson")]
     public class glTF_VRM_Firstperson : UniGLTF.JsonSerializableBase
     {
-        [JsonSchema(Description = "The bone whose rendering should be turned off in first-person view. Usually Head is specified.")]
+        // When the value is -1, it means that no bone for first person is found.
+        [JsonSchema(Description = "The bone whose rendering should be turned off in first-person view. Usually Head is specified.", Minimum = 0, ExplicitIgnorableValue = -1)]
         public int firstPersonBone = -1;
 
         [JsonSchema(Description = @"The target position of the VR headset in first-person view. It is assumed that an offset from the head bone to the VR headset is added.")]

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Humanoid.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Humanoid.cs
@@ -162,7 +162,8 @@ namespace VRM
             }
         }
 
-        [JsonSchema(Description = "Reference node index")]
+        // When the value is -1, it means that no node is found.
+        [JsonSchema(Description = "Reference node index", Minimum = 0)]
         public int node = -1;
 
         [JsonSchema(Description = "Unity's HumanLimit.useDefaultValues")]

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
@@ -54,7 +54,8 @@ namespace VRM
         [JsonSchema(Description = "Reference of VRM model")]
         public string reference;
 
-        [JsonSchema(Description = "Thumbnail of VRM model")]
+        // When the value is -1, it means that texture is not specified.
+        [JsonSchema(Description = "Thumbnail of VRM model", Minimum = 0, ExplicitIgnorableValue = -1)]
         public int texture = -1;
 
         #region Ussage Permission

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_SecondaryAnimation.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_SecondaryAnimation.cs
@@ -28,7 +28,7 @@ namespace VRM
     [JsonSchema(Title = "vrm.secondaryanimation.collidergroup", Description = @"Set sphere balls for colliders used for collision detections with swaying objects.")]
     public class glTF_VRM_SecondaryAnimationColliderGroup : JsonSerializableBase
     {
-        [JsonSchema(Description = "The node of the collider group for setting up collision detections.")]
+        [JsonSchema(Description = "The node of the collider group for setting up collision detections.", Minimum = 0)]
         public int node;
 
         public List<glTF_VRM_SecondaryAnimationCollider> colliders = new List<glTF_VRM_SecondaryAnimationCollider>();
@@ -60,6 +60,9 @@ namespace VRM
         [JsonSchema(Description = "The resistance (deceleration) of automatic animation.")]
         public float dragForce;
 
+        // NOTE: This value denotes index but may contain -1 as a value.
+        // When the value is -1, it means that center node is not specified.
+        // This is a historical issue and a compromise for forward compatibility.
         [JsonSchema(Description = @"The reference point of a swaying object can be set at any location except the origin. When implementing UI moving with warp, the parent node to move with warp can be specified if you don't want to make the object swaying with warp movement.")]
         public int center;
 
@@ -67,9 +70,11 @@ namespace VRM
         public float hitRadius;
 
         [JsonSchema(Description = "Specify the node index of the root bone of the swaying object.")]
+        [ItemJsonSchema(Minimum = 0)]
         public int[] bones = new int[] { };
 
         [JsonSchema(Description = "Specify the index of the collider group for collisions with swaying objects.")]
+        [ItemJsonSchema(Minimum = 0)]
         public int[] colliderGroups = new int[] { };
 
         protected override void SerializeMembers(GLTFJsonFormatter f)


### PR DESCRIPTION
Resolve #91 (partially).

Changes are below.

- `vrm.firstperson.firstPersonBone`
  - Add `minimum=0`
  - Now ignore a field when `-1` is specified when exporting
- `vrm.firstperson.meshannotation.mesh`
  - Add `minimum=0`
- `vrm.meta.texture`
  - Add `minimum=0`
  - Now ignore a field when `-1` is specified when exporting
- `vrm.humanoid.bone.node`
  - Add `minimum=0`
- `vrm.secondaryanimation.spring.center`
  - DO NOTHING for compatibility
- `vrm.secondaryanimation.spring.bones`
  - Add `minimum=0` for elements
- `vrm.secondaryanimation.spring.colliderGroups`
  - Add `minimum=0` for elements
- `vrm.secondaryanimation.collidergroup.node`
  - Add `minimum=0` for elements

I have checked that VRM files exported with this version can be read with UniVRM 0.46c.

NOTE: `vrm.secondaryanimation.spring.center` cannot be changed because of compatibility problems.