### PR TITLE
Fix normal maps are broken on Android(and also iOS) platforms

### DIFF
--- a/Assets/VRM/UniGLTF/Resources/Shaders/NormalMapEncoder.shader
+++ b/Assets/VRM/UniGLTF/Resources/Shaders/NormalMapEncoder.shader
@@ -41,7 +41,14 @@
 
 			fixed4 frag(v2f i) : SV_Target
 			{
+
 				half4 col = tex2D(_MainTex, i.uv);
+
+#if defined(UNITY_NO_DXT5nm)
+                // This is a trick from UnpackNormal in UnityCG.cginc !!!!
+                return col;
+#endif
+
 				half4 normal;
 				normal.x = 1.0;
 				normal.y = col.y;

--- a/Assets/VRM/UniGLTF/Resources/Shaders/NormalMapEncoder.shader
+++ b/Assets/VRM/UniGLTF/Resources/Shaders/NormalMapEncoder.shader
@@ -41,12 +41,11 @@
 
 			fixed4 frag(v2f i) : SV_Target
 			{
-
 				half4 col = tex2D(_MainTex, i.uv);
 
 #if defined(UNITY_NO_DXT5nm)
-                // This is a trick from UnpackNormal in UnityCG.cginc !!!!
-                return col;
+				// This is a trick from UnpackNormal in UnityCG.cginc !!!!
+				return col;
 #endif
 
 				half4 normal;

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureConverter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureConverter.cs
@@ -111,6 +111,8 @@ namespace UniGLTF
             return m_encoder;
         }
 
+        // GLTF data to Unity texture
+        // ConvertToNormalValueFromRawColorWhenCompressionIsRequired
         public Texture2D GetImportTexture(Texture2D texture)
         {
             var mat = GetEncoder();
@@ -119,6 +121,8 @@ namespace UniGLTF
             return converted;
         }
 
+        // Unity texture to GLTF data
+        // ConvertToRawColorWhenNormalValueIsCompressed
         public Texture2D GetExportTexture(Texture2D texture)
         {
             var mat = GetDecoder();

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureConverter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureConverter.cs
@@ -113,9 +113,6 @@ namespace UniGLTF
 
         public Texture2D GetImportTexture(Texture2D texture)
         {
-#if UNITY_WEBGL && !UNITY_EDITOR
-            return texture;
-#endif
             var mat = GetEncoder();
             var converted = TextureConverter.Convert(texture, glTFTextureTypes.Normal, null, mat);
             TextureConverter.AppendTextureExtension(converted, m_extension);
@@ -124,6 +121,7 @@ namespace UniGLTF
 
         public Texture2D GetExportTexture(Texture2D texture)
         {
+
 #if UNITY_WEBGL && !UNITY_EDITOR
             return texture;
 #endif

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureConverter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureConverter.cs
@@ -121,10 +121,6 @@ namespace UniGLTF
 
         public Texture2D GetExportTexture(Texture2D texture)
         {
-
-#if UNITY_WEBGL && !UNITY_EDITOR
-            return texture;
-#endif
             var mat = GetDecoder();
             var converted = TextureConverter.Convert(texture, glTFTextureTypes.Normal, null, mat);
             TextureConverter.RemoveTextureExtension(converted, m_extension);


### PR DESCRIPTION
Resolve #73. 

Switch logic for converting textures in the shader instead of in C#.