### PR TITLE
Now some fields in meta are required

### DIFF
--- a/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
@@ -242,10 +242,11 @@ namespace VRM
                 licenseName = "CC0",
                 allowedUserName = "OnlyAuthor",
                 violentUssageName = "Disallow",
+                sexualUssageName = "Disallow",
             };
 
             var json = model.ToJson();
-            Assert.AreEqual(@"{""texture"":-1,""allowedUserName"":""OnlyAuthor"",""violentUssageName"":""Disallow"",""licenseName"":""CC0""}", json);
+            Assert.AreEqual(@"{""texture"":-1,""allowedUserName"":""OnlyAuthor"",""violentUssageName"":""Disallow"",""sexualUssageName"":""Disallow"",""licenseName"":""CC0""}", json);
             Debug.Log(json);
 
             var c = new JsonSchemaValidationContext("")
@@ -254,7 +255,7 @@ namespace VRM
             };
             var json2 = JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c);
             // NOTE: New serializer outputs values which will not be used...
-            Assert.AreEqual(@"{""allowedUserName"":""OnlyAuthor"",""violentUssageName"":""Disallow"",""licenseName"":""CC0""}",json2);
+            Assert.AreEqual(@"{""allowedUserName"":""OnlyAuthor"",""violentUssageName"":""Disallow"",""sexualUssageName"":""Disallow"",""licenseName"":""CC0""}",json2);
         }
 
         [Test]
@@ -279,6 +280,7 @@ namespace VRM
                     allowedUserName = "OnlyAuthor",
                     violentUssageName = "Disallow",
                     licenseName = "_INVALID_SOME_THING_",
+                    sexualUssageName = "Disallow",
                 };
 
                 var c = new JsonSchemaValidationContext("")
@@ -297,6 +299,7 @@ namespace VRM
                     // allowedUserName = "OnlyAuthor",
                     licenseName = "CC0",
                     violentUssageName = "Disallow",
+                    sexualUssageName = "Disallow",
                 };
 
                 var c = new JsonSchemaValidationContext("")
@@ -314,6 +317,7 @@ namespace VRM
                 {
                     allowedUserName = "_INVALID_SOME_THING_",
                     violentUssageName = "Disallow",
+                    sexualUssageName = "Disallow",
                     licenseName = "CC0",
                 };
 
@@ -332,6 +336,7 @@ namespace VRM
                 {
                     allowedUserName = "OnlyAuthor",
                     //violentUssageName = "Disallow",
+                    sexualUssageName = "Disallow",
                     licenseName = "CC0",
                 };
 
@@ -350,6 +355,7 @@ namespace VRM
                 {
                     allowedUserName = "OnlyAuthor",
                     violentUssageName = "_INVALID_SOME_THING_",
+                    sexualUssageName = "Disallow",
                     licenseName = "CC0",
                 };
 
@@ -361,6 +367,44 @@ namespace VRM
                     () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
                 );
                 Assert.AreEqual("[violentUssageName.String] _INVALID_SOME_THING_ is not valid enum", ex.Message);
+            }
+
+            {
+                var model = new glTF_VRM_Meta()
+                {
+                    allowedUserName = "OnlyAuthor",
+                    violentUssageName = "Disallow",
+                    //sexualUssageName = "Disallow",
+                    licenseName = "CC0",
+                };
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[sexualUssageName.String] null", ex.Message);
+            }
+
+            {
+                var model = new glTF_VRM_Meta()
+                {
+                    allowedUserName = "OnlyAuthor",
+                    violentUssageName = "Disallow",
+                    sexualUssageName = "_INVALID_SOME_THING_",
+                    licenseName = "CC0",
+                };
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[sexualUssageName.String] _INVALID_SOME_THING_ is not valid enum", ex.Message);
             }
         }
 

--- a/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
@@ -241,10 +241,11 @@ namespace VRM
             {
                 licenseName = "CC0",
                 allowedUserName = "OnlyAuthor",
+                violentUssageName = "Disallow",
             };
 
             var json = model.ToJson();
-            Assert.AreEqual(@"{""texture"":-1,""allowedUserName"":""OnlyAuthor"",""licenseName"":""CC0""}", json);
+            Assert.AreEqual(@"{""texture"":-1,""allowedUserName"":""OnlyAuthor"",""violentUssageName"":""Disallow"",""licenseName"":""CC0""}", json);
             Debug.Log(json);
 
             var c = new JsonSchemaValidationContext("")
@@ -253,7 +254,7 @@ namespace VRM
             };
             var json2 = JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c);
             // NOTE: New serializer outputs values which will not be used...
-            Assert.AreEqual(@"{""allowedUserName"":""OnlyAuthor"",""licenseName"":""CC0""}",json2);
+            Assert.AreEqual(@"{""allowedUserName"":""OnlyAuthor"",""violentUssageName"":""Disallow"",""licenseName"":""CC0""}",json2);
         }
 
         [Test]
@@ -276,6 +277,7 @@ namespace VRM
                 var model = new glTF_VRM_Meta()
                 {
                     allowedUserName = "OnlyAuthor",
+                    violentUssageName = "Disallow",
                     licenseName = "_INVALID_SOME_THING_",
                 };
 
@@ -292,7 +294,9 @@ namespace VRM
             {
                 var model = new glTF_VRM_Meta()
                 {
+                    // allowedUserName = "OnlyAuthor",
                     licenseName = "CC0",
+                    violentUssageName = "Disallow",
                 };
 
                 var c = new JsonSchemaValidationContext("")
@@ -309,6 +313,7 @@ namespace VRM
                 var model = new glTF_VRM_Meta()
                 {
                     allowedUserName = "_INVALID_SOME_THING_",
+                    violentUssageName = "Disallow",
                     licenseName = "CC0",
                 };
 
@@ -320,6 +325,42 @@ namespace VRM
                     () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
                 );
                 Assert.AreEqual("[allowedUserName.String] _INVALID_SOME_THING_ is not valid enum", ex.Message);
+            }
+
+            {
+                var model = new glTF_VRM_Meta()
+                {
+                    allowedUserName = "OnlyAuthor",
+                    //violentUssageName = "Disallow",
+                    licenseName = "CC0",
+                };
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[violentUssageName.String] null", ex.Message);
+            }
+
+            {
+                var model = new glTF_VRM_Meta()
+                {
+                    allowedUserName = "OnlyAuthor",
+                    violentUssageName = "_INVALID_SOME_THING_",
+                    licenseName = "CC0",
+                };
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[violentUssageName.String] _INVALID_SOME_THING_ is not valid enum", ex.Message);
             }
         }
 

--- a/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
@@ -240,10 +240,11 @@ namespace VRM
             var model = new glTF_VRM_Meta()
             {
                 licenseName = "CC0",
+                allowedUserName = "OnlyAuthor",
             };
 
-        var json = model.ToJson();
-            Assert.AreEqual(@"{""texture"":-1,""licenseName"":""CC0""}", json);
+            var json = model.ToJson();
+            Assert.AreEqual(@"{""texture"":-1,""allowedUserName"":""OnlyAuthor"",""licenseName"":""CC0""}", json);
             Debug.Log(json);
 
             var c = new JsonSchemaValidationContext("")
@@ -252,22 +253,74 @@ namespace VRM
             };
             var json2 = JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c);
             // NOTE: New serializer outputs values which will not be used...
-            Assert.AreEqual(@"{""licenseName"":""CC0""}",json2);
+            Assert.AreEqual(@"{""allowedUserName"":""OnlyAuthor"",""licenseName"":""CC0""}",json2);
         }
 
         [Test]
         public void MetaTestError()
         {
-            var model = new glTF_VRM_Meta();
-
-            var c = new JsonSchemaValidationContext("")
             {
-                EnableDiagnosisForNotRequiredFields = true,
-            };
-            var ex = Assert.Throws<JsonSchemaValidationException>(
-                () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
-            );
-            Assert.AreEqual("[licenseName.String] null", ex.Message);
+                var model = new glTF_VRM_Meta();
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[allowedUserName.String] null", ex.Message);
+            }
+
+            {
+                var model = new glTF_VRM_Meta()
+                {
+                    allowedUserName = "OnlyAuthor",
+                    licenseName = "_INVALID_SOME_THING_",
+                };
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[licenseName.String] _INVALID_SOME_THING_ is not valid enum", ex.Message);
+            }
+
+            {
+                var model = new glTF_VRM_Meta()
+                {
+                    licenseName = "CC0",
+                };
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[allowedUserName.String] null", ex.Message);
+            }
+
+            {
+                var model = new glTF_VRM_Meta()
+                {
+                    allowedUserName = "_INVALID_SOME_THING_",
+                    licenseName = "CC0",
+                };
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[allowedUserName.String] _INVALID_SOME_THING_ is not valid enum", ex.Message);
+            }
         }
 
         // TODO: Move to another suitable location

--- a/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
@@ -239,10 +239,10 @@ namespace VRM
         {
             var model = new glTF_VRM_Meta()
             {
-                licenseName = "CC0",
                 allowedUserName = "OnlyAuthor",
                 violentUssageName = "Disallow",
                 sexualUssageName = "Disallow",
+                licenseName = "CC0",
             };
 
             var json = model.ToJson();
@@ -279,8 +279,27 @@ namespace VRM
                 {
                     allowedUserName = "OnlyAuthor",
                     violentUssageName = "Disallow",
-                    licenseName = "_INVALID_SOME_THING_",
                     sexualUssageName = "Disallow",
+                    //licenseName = "CC0",
+                };
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[licenseName.String] null", ex.Message);
+            }
+
+            {
+                var model = new glTF_VRM_Meta()
+                {
+                    allowedUserName = "OnlyAuthor",
+                    violentUssageName = "Disallow",
+                    sexualUssageName = "Disallow",
+                    licenseName = "_INVALID_SOME_THING_",
                 };
 
                 var c = new JsonSchemaValidationContext("")
@@ -297,9 +316,9 @@ namespace VRM
                 var model = new glTF_VRM_Meta()
                 {
                     // allowedUserName = "OnlyAuthor",
-                    licenseName = "CC0",
                     violentUssageName = "Disallow",
                     sexualUssageName = "Disallow",
+                    licenseName = "CC0",
                 };
 
                 var c = new JsonSchemaValidationContext("")

--- a/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
@@ -242,11 +242,12 @@ namespace VRM
                 allowedUserName = "OnlyAuthor",
                 violentUssageName = "Disallow",
                 sexualUssageName = "Disallow",
+                commercialUssageName = "Disallow",
                 licenseName = "CC0",
             };
 
             var json = model.ToJson();
-            Assert.AreEqual(@"{""texture"":-1,""allowedUserName"":""OnlyAuthor"",""violentUssageName"":""Disallow"",""sexualUssageName"":""Disallow"",""licenseName"":""CC0""}", json);
+            Assert.AreEqual(@"{""texture"":-1,""allowedUserName"":""OnlyAuthor"",""violentUssageName"":""Disallow"",""sexualUssageName"":""Disallow"",""commercialUssageName"":""Disallow"",""licenseName"":""CC0""}", json);
             Debug.Log(json);
 
             var c = new JsonSchemaValidationContext("")
@@ -255,7 +256,7 @@ namespace VRM
             };
             var json2 = JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c);
             // NOTE: New serializer outputs values which will not be used...
-            Assert.AreEqual(@"{""allowedUserName"":""OnlyAuthor"",""violentUssageName"":""Disallow"",""sexualUssageName"":""Disallow"",""licenseName"":""CC0""}",json2);
+            Assert.AreEqual(@"{""allowedUserName"":""OnlyAuthor"",""violentUssageName"":""Disallow"",""sexualUssageName"":""Disallow"",""commercialUssageName"":""Disallow"",""licenseName"":""CC0""}",json2);
         }
 
         [Test]
@@ -280,6 +281,7 @@ namespace VRM
                     allowedUserName = "OnlyAuthor",
                     violentUssageName = "Disallow",
                     sexualUssageName = "Disallow",
+                    commercialUssageName = "Disallow",
                     //licenseName = "CC0",
                 };
 
@@ -299,6 +301,7 @@ namespace VRM
                     allowedUserName = "OnlyAuthor",
                     violentUssageName = "Disallow",
                     sexualUssageName = "Disallow",
+                    commercialUssageName = "Disallow",
                     licenseName = "_INVALID_SOME_THING_",
                 };
 
@@ -318,6 +321,7 @@ namespace VRM
                     // allowedUserName = "OnlyAuthor",
                     violentUssageName = "Disallow",
                     sexualUssageName = "Disallow",
+                    commercialUssageName = "Disallow",
                     licenseName = "CC0",
                 };
 
@@ -337,6 +341,7 @@ namespace VRM
                     allowedUserName = "_INVALID_SOME_THING_",
                     violentUssageName = "Disallow",
                     sexualUssageName = "Disallow",
+                    commercialUssageName = "Disallow",
                     licenseName = "CC0",
                 };
 
@@ -356,6 +361,7 @@ namespace VRM
                     allowedUserName = "OnlyAuthor",
                     //violentUssageName = "Disallow",
                     sexualUssageName = "Disallow",
+                    commercialUssageName = "Disallow",
                     licenseName = "CC0",
                 };
 
@@ -375,6 +381,7 @@ namespace VRM
                     allowedUserName = "OnlyAuthor",
                     violentUssageName = "_INVALID_SOME_THING_",
                     sexualUssageName = "Disallow",
+                    commercialUssageName = "Disallow",
                     licenseName = "CC0",
                 };
 
@@ -394,6 +401,7 @@ namespace VRM
                     allowedUserName = "OnlyAuthor",
                     violentUssageName = "Disallow",
                     //sexualUssageName = "Disallow",
+                    commercialUssageName = "Disallow",
                     licenseName = "CC0",
                 };
 
@@ -413,6 +421,7 @@ namespace VRM
                     allowedUserName = "OnlyAuthor",
                     violentUssageName = "Disallow",
                     sexualUssageName = "_INVALID_SOME_THING_",
+                    commercialUssageName = "Disallow",
                     licenseName = "CC0",
                 };
 
@@ -424,6 +433,46 @@ namespace VRM
                     () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
                 );
                 Assert.AreEqual("[sexualUssageName.String] _INVALID_SOME_THING_ is not valid enum", ex.Message);
+            }
+
+            {
+                var model = new glTF_VRM_Meta()
+                {
+                    allowedUserName = "OnlyAuthor",
+                    violentUssageName = "Disallow",
+                    sexualUssageName = "Disallow",
+                    //commercialUssageName = "Disallow",
+                    licenseName = "CC0",
+                };
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[commercialUssageName.String] null", ex.Message);
+            }
+
+            {
+                var model = new glTF_VRM_Meta()
+                {
+                    allowedUserName = "OnlyAuthor",
+                    violentUssageName = "Disallow",
+                    sexualUssageName = "Disallow",
+                    commercialUssageName = "_INVALID_SOME_THING_",
+                    licenseName = "CC0",
+                };
+
+                var c = new JsonSchemaValidationContext("")
+                {
+                    EnableDiagnosisForNotRequiredFields = true,
+                };
+                var ex = Assert.Throws<JsonSchemaValidationException>(
+                    () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+                );
+                Assert.AreEqual("[commercialUssageName.String] _INVALID_SOME_THING_ is not valid enum", ex.Message);
             }
         }
 

--- a/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/UniVRMSerializeTests.cs
@@ -237,10 +237,13 @@ namespace VRM
         [Test]
         public void MetaTest()
         {
-            var model = new glTF_VRM_Meta();
+            var model = new glTF_VRM_Meta()
+            {
+                licenseName = "CC0",
+            };
 
-            var json = model.ToJson();
-            Assert.AreEqual(@"{""texture"":-1}", json);
+        var json = model.ToJson();
+            Assert.AreEqual(@"{""texture"":-1,""licenseName"":""CC0""}", json);
             Debug.Log(json);
 
             var c = new JsonSchemaValidationContext("")
@@ -249,7 +252,22 @@ namespace VRM
             };
             var json2 = JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c);
             // NOTE: New serializer outputs values which will not be used...
-            Assert.AreEqual(@"{}",json2);
+            Assert.AreEqual(@"{""licenseName"":""CC0""}",json2);
+        }
+
+        [Test]
+        public void MetaTestError()
+        {
+            var model = new glTF_VRM_Meta();
+
+            var c = new JsonSchemaValidationContext("")
+            {
+                EnableDiagnosisForNotRequiredFields = true,
+            };
+            var ex = Assert.Throws<JsonSchemaValidationException>(
+                () => JsonSchema.FromType<glTF_VRM_Meta>().Serialize(model, c)
+            );
+            Assert.AreEqual("[licenseName.String] null", ex.Message);
         }
 
         // TODO: Move to another suitable location

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
@@ -101,7 +101,7 @@ namespace VRM
             set { sexualUssageName = value.ToString(); }
         }
 
-        [JsonSchema(Description = "For commercial use", EnumValues = new object[]
+        [JsonSchema(Required = true, Description = "For commercial use", EnumValues = new object[]
         {
         "Disallow",
         "Allow",

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
@@ -89,7 +89,7 @@ namespace VRM
             set { violentUssageName = value.ToString(); }
         }
 
-        [JsonSchema(Description = "Permission to perform sexual acts with this avatar", EnumValues = new object[]
+        [JsonSchema(Required = true, Description = "Permission to perform sexual acts with this avatar", EnumValues = new object[]
         {
         "Disallow",
         "Allow",

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
@@ -59,7 +59,7 @@ namespace VRM
         public int texture = -1;
 
         #region Ussage Permission
-        [JsonSchema(Description = "A person who can perform with this avatar ", EnumValues = new object[] {
+        [JsonSchema(Required = true, Description = "A person who can perform with this avatar ", EnumValues = new object[] {
             "OnlyAuthor",
             "ExplicitlyLicensedPerson",
             "Everyone",

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
@@ -77,7 +77,7 @@ namespace VRM
             }
         }
 
-        [JsonSchema(Description = "Permission to perform violent acts with this avatar", EnumValues = new object[]
+        [JsonSchema(Required = true, Description = "Permission to perform violent acts with this avatar", EnumValues = new object[]
         {
         "Disallow",
         "Allow",

--- a/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/glTF_VRM_Meta.cs
@@ -118,7 +118,7 @@ namespace VRM
         #endregion
 
         #region Distribution License
-        [JsonSchema(Description = "License type", EnumValues = new object[]
+        [JsonSchema(Required = true, Description = "License type", EnumValues = new object[]
         {
             "Redistribution_Prohibited",
             "CC0",


### PR DESCRIPTION
(json schema definitions are not affected by this PR now)

Fields below

- `allowedUserName`
- `violentUssageName`
- `sexualUssageName`
- `commercialUssageName`
- `licenseName`

are now required when exporting. Empty or invalid values are not allowed.