### PR TITLE
Removed Expression.Compile

### DIFF
--- a/Assets/VRM/UniJSON/Editor/Tests/GenericCallUtilityTests.cs
+++ b/Assets/VRM/UniJSON/Editor/Tests/GenericCallUtilityTests.cs
@@ -31,11 +31,11 @@ namespace UniJSON
 
             var mi = s.GetType().GetMethod("Set");
 
-            var invoke = (Action<Sample, int>)GenericInvokeCallFactory.Create<Sample, int>(mi);
+            var invoke = GenericInvokeCallFactory.CreateAction<Sample, int>(mi);
             invoke(s, 1);
             Assert.AreEqual(1, s.Value);
 
-            var exp = (Action<Sample, int>)GenericExpressionCallFactory.Create<Sample, int>(mi);
+            var exp = GenericExpressionCallFactory.Create<Sample, int>(mi);
             exp(s, 2);
             Assert.AreEqual(2, s.Value);
         }

--- a/Assets/VRM/UniJSON/Editor/Tests/GenericCallUtilityTests.cs
+++ b/Assets/VRM/UniJSON/Editor/Tests/GenericCallUtilityTests.cs
@@ -20,6 +20,11 @@ namespace UniJSON
             {
                 Value = value;
             }
+
+            public int Get(int _)
+            {
+                return Value;
+            }
         }
 
 
@@ -29,15 +34,27 @@ namespace UniJSON
         {
             var s = new Sample();
 
-            var mi = s.GetType().GetMethod("Set");
 
-            var invoke = GenericInvokeCallFactory.CreateAction<Sample, int>(mi);
-            invoke(s, 1);
-            Assert.AreEqual(1, s.Value);
+            {
+                var mi = s.GetType().GetMethod("Set");
+                var action = GenericInvokeCallFactory.OpenAction<Sample, int>(mi);
+                action(s, 1);
+                Assert.AreEqual(1, s.Value);
+            }
 
-            var exp = GenericExpressionCallFactory.Create<Sample, int>(mi);
-            exp(s, 2);
-            Assert.AreEqual(2, s.Value);
+            {
+                var mi = s.GetType().GetMethod("Get");
+                var func = GenericInvokeCallFactory.OpenFunc<Sample, int, int>(mi);
+                var value = func(s, 1);
+                Assert.AreEqual(1, s.Value);
+            }
+
+            {
+                var mi = s.GetType().GetMethod("Set");
+                var action = GenericExpressionCallFactory.Create<Sample, int>(mi);
+                action(s, 2);
+                Assert.AreEqual(2, s.Value);
+            }
         }
     }
 }

--- a/Assets/VRM/UniJSON/Scripts/FormatterExtensionsSerializer.cs
+++ b/Assets/VRM/UniJSON/Scripts/FormatterExtensionsSerializer.cs
@@ -84,7 +84,7 @@ namespace UniJSON
             if (typeof(T) == typeof(object) && t.GetType() != typeof(object))
             {
                 var mi = FormatterExtensionsSerializer.GetMethod("SerializeObject");
-                return GenericInvokeCallFactory.Create<IFormatter, T>(mi);
+                return GenericInvokeCallFactory.CreateAction<IFormatter, T>(mi);
             }
 
             try
@@ -93,7 +93,7 @@ namespace UniJSON
                 var mi = typeof(IFormatter).GetMethod("Value", new Type[] { t });
                 if (mi != null)
                 {
-                    return GenericInvokeCallFactory.Create<IFormatter, T>(mi);
+                    return GenericInvokeCallFactory.CreateAction<IFormatter, T>(mi);
                 }
             }
             catch (AmbiguousMatchException)
@@ -111,7 +111,7 @@ namespace UniJSON
                 if (idictionary != null)
                 {
                     var mi = FormatterExtensionsSerializer.GetMethod("SerializeDictionary");
-                    return GenericInvokeCallFactory.Create<IFormatter, T>(mi);
+                    return GenericInvokeCallFactory.CreateAction<IFormatter, T>(mi);
                 }
             }
 
@@ -120,7 +120,7 @@ namespace UniJSON
                 if (t == typeof(object[]))
                 {
                     var mi = FormatterExtensionsSerializer.GetMethod("SerializeObjectArray");
-                    return GenericInvokeCallFactory.Create<IFormatter, T>(mi);
+                    return GenericInvokeCallFactory.CreateAction<IFormatter, T>(mi);
                 }
             }
 
@@ -134,7 +134,7 @@ namespace UniJSON
                 {
                     var g = FormatterExtensionsSerializer.GetMethod("SerializeArray");
                     var mi = g.MakeGenericMethod(ienumerable.GetGenericArguments());
-                    return GenericInvokeCallFactory.Create<IFormatter, T>(mi);
+                    return GenericInvokeCallFactory.CreateAction<IFormatter, T>(mi);
                 }
             }
 

--- a/Assets/VRM/UniJSON/Scripts/FormatterExtensionsSerializer.cs
+++ b/Assets/VRM/UniJSON/Scripts/FormatterExtensionsSerializer.cs
@@ -84,7 +84,7 @@ namespace UniJSON
             if (typeof(T) == typeof(object) && t.GetType() != typeof(object))
             {
                 var mi = FormatterExtensionsSerializer.GetMethod("SerializeObject");
-                return GenericInvokeCallFactory.CreateAction<IFormatter, T>(mi);
+                return GenericInvokeCallFactory.StaticAction<IFormatter, T>(mi);
             }
 
             try
@@ -93,7 +93,7 @@ namespace UniJSON
                 var mi = typeof(IFormatter).GetMethod("Value", new Type[] { t });
                 if (mi != null)
                 {
-                    return GenericInvokeCallFactory.CreateAction<IFormatter, T>(mi);
+                    return GenericInvokeCallFactory.OpenAction<IFormatter, T>(mi);
                 }
             }
             catch (AmbiguousMatchException)
@@ -111,7 +111,7 @@ namespace UniJSON
                 if (idictionary != null)
                 {
                     var mi = FormatterExtensionsSerializer.GetMethod("SerializeDictionary");
-                    return GenericInvokeCallFactory.CreateAction<IFormatter, T>(mi);
+                    return GenericInvokeCallFactory.StaticAction<IFormatter, T>(mi);
                 }
             }
 
@@ -120,7 +120,7 @@ namespace UniJSON
                 if (t == typeof(object[]))
                 {
                     var mi = FormatterExtensionsSerializer.GetMethod("SerializeObjectArray");
-                    return GenericInvokeCallFactory.CreateAction<IFormatter, T>(mi);
+                    return GenericInvokeCallFactory.StaticAction<IFormatter, T>(mi);
                 }
             }
 
@@ -134,7 +134,7 @@ namespace UniJSON
                 {
                     var g = FormatterExtensionsSerializer.GetMethod("SerializeArray");
                     var mi = g.MakeGenericMethod(ienumerable.GetGenericArguments());
-                    return GenericInvokeCallFactory.CreateAction<IFormatter, T>(mi);
+                    return GenericInvokeCallFactory.StaticAction<IFormatter, T>(mi);
                 }
             }
 

--- a/Assets/VRM/UniJSON/Scripts/GenericCallUtility/GenericInvokeCallFactory.cs
+++ b/Assets/VRM/UniJSON/Scripts/GenericCallUtility/GenericInvokeCallFactory.cs
@@ -65,10 +65,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format(""{0} is not static"", m));
             }
 
-            return ($1) =>
-            {
-                m.Invoke(null, new object[] { $1 });
-            };
+            return (Action<$0>)Delegate.CreateDelegate(typeof(Action<$0>), null, m);
         }
 ".Replace("$0", g).Replace("$1", a);
 
@@ -91,10 +88,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format(""{0} is static"", m));
             }
 
-            return (s, $1) =>
-            {
-                m.Invoke(s, new object[] { $1 });
-            };
+            return (Action<S, $0>)Delegate.CreateDelegate(typeof(Action<S, $0>), m);
         }
 ".Replace("$0", g).Replace("$1", a);
 
@@ -117,10 +111,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format(""{0} is static"", m));
             }
 
-            return ($1) =>
-            {
-                m.Invoke(instance, new object[] { $1 });
-            };
+            return (Action<$0>)Delegate.CreateDelegate(typeof(Action<$0>), instance, m);
         }
 ".Replace("$0", g).Replace("$1", a);
 
@@ -143,7 +134,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format(""{0} is not static"", m));
             }
 
-            return ($1) => (T)m.Invoke(null, new object[] { $1 });
+            return (Func<$0, T>)Delegate.CreateDelegate(typeof(Func<$0, T>), null, m);
         }
 ".Replace("$0", g).Replace("$1", a);
 
@@ -166,7 +157,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format(""{0} is static"", m));
             }
 
-            return (s, $1) => (T)m.Invoke(s, new object[] { $1 });
+            return (Func<S, $0, T>)Delegate.CreateDelegate(typeof(Func<S, $0, T>), m);
         }
 ".Replace("$0", g).Replace("$1", a);
 
@@ -189,7 +180,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format(""{0} is static"", m));
             }
 
-            return ($1) => (T)m.Invoke(instance, new object[] { $1 });
+            return (Func<$0, T>)Delegate.CreateDelegate(typeof(Func<$0, T>), instance, m);
         }
 ".Replace("$0", g).Replace("$1", a);
 
@@ -218,10 +209,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is not static", m));
             }
 
-            return () =>
-            {
-                m.Invoke(null, new object[] { });
-            };
+            return (Action)Delegate.CreateDelegate(typeof(Action), null, m);
         }
 
         public static Action<S> OpenAction<S>(MethodInfo m)

--- a/Assets/VRM/UniJSON/Scripts/GenericCallUtility/GenericInvokeCallFactory.cs
+++ b/Assets/VRM/UniJSON/Scripts/GenericCallUtility/GenericInvokeCallFactory.cs
@@ -43,7 +43,7 @@ namespace UniJSON
 ");
 
                 // CreateWithThis
-                w.WriteLine("//////////// Create");
+                w.WriteLine("//////////// CreateAction");
 
                 // Create
                 for (int i = 1; i <= ARGS && i< NET35MAX; ++i)
@@ -54,7 +54,7 @@ namespace UniJSON
 
 
                     var source = @"
-        public static Action<S, $0> Create<S, $0>(MethodInfo m)
+        public static Action<S, $0> CreateAction<S, $0>(MethodInfo m)
         {
             Action<S, $0> callback = null;
             if (m.IsStatic)
@@ -88,7 +88,7 @@ namespace UniJSON
                     var a = String.Join(", ", GetArgs("a", i).ToArray());
 
                     var source = @"
-        public static Action<$0> CreateWithThis<S, $0>(MethodInfo m, S instance)
+        public static Action<$0> CreateActionBindThis<S, $0>(MethodInfo m, S instance)
         {
             if (m.IsStatic)
             {
@@ -130,8 +130,8 @@ namespace UniJSON
         }
 #endif
 
-        #region no arguments
-        public static Action<S> Create<S>(MethodInfo m)
+        #region zero arguments
+        public static Action<S> CreateAction<S>(MethodInfo m)
         {
             return (s) =>
             {
@@ -139,7 +139,15 @@ namespace UniJSON
             };
         }
 
-        public static Action CreateWithThis<S>(MethodInfo m, S instance)
+        public static Func<S, T> CreateFunc<S, T>(MethodInfo m)
+        {
+            return (s) =>
+            {
+                return (T)m.Invoke(s, new object[] { });
+            };
+        }
+
+        public static Action CreateActionBindThis<S>(MethodInfo m, S instance)
         {
             return () =>
             {

--- a/Assets/VRM/UniJSON/Scripts/GenericCallUtility/GenericInvokeCallFactory.g.cs
+++ b/Assets/VRM/UniJSON/Scripts/GenericCallUtility/GenericInvokeCallFactory.g.cs
@@ -8,173 +8,285 @@ namespace UniJSON
     public static partial class GenericInvokeCallFactory
     {
 
-//////////// CreateAction
+//////////// StaticAction
 
-        public static Action<S, A0> CreateAction<S, A0>(MethodInfo m)
+        public static Action<A0> StaticAction<A0>(MethodInfo m)
         {
-            Action<S, A0> callback = null;
-            if (m.IsStatic)
+            if (!m.IsStatic)
             {
-                callback = (s, a0) =>
-                {
-                    m.Invoke(null, new object[] { s, a0 });
-                };
-            }
-            else
-            {
-                callback = (s, a0) =>
-                {
-                    m.Invoke(s, new object[] { a0 });
-                };
-            }
-            return callback;
-        }
-
-
-        public static Action<S, A0, A1> CreateAction<S, A0, A1>(MethodInfo m)
-        {
-            Action<S, A0, A1> callback = null;
-            if (m.IsStatic)
-            {
-                callback = (s, a0, a1) =>
-                {
-                    m.Invoke(null, new object[] { s, a0, a1 });
-                };
-            }
-            else
-            {
-                callback = (s, a0, a1) =>
-                {
-                    m.Invoke(s, new object[] { a0, a1 });
-                };
-            }
-            return callback;
-        }
-
-
-        public static Action<S, A0, A1, A2> CreateAction<S, A0, A1, A2>(MethodInfo m)
-        {
-            Action<S, A0, A1, A2> callback = null;
-            if (m.IsStatic)
-            {
-                callback = (s, a0, a1, a2) =>
-                {
-                    m.Invoke(null, new object[] { s, a0, a1, a2 });
-                };
-            }
-            else
-            {
-                callback = (s, a0, a1, a2) =>
-                {
-                    m.Invoke(s, new object[] { a0, a1, a2 });
-                };
-            }
-            return callback;
-        }
-
-//////////// CreateWithThis
-
-        public static Action<A0> CreateActionBindThis<S, A0>(MethodInfo m, S instance)
-        {
-            if (m.IsStatic)
-            {
-                if (instance != null)
-                {
-                    throw new ArgumentException();
-                }
-            }
-            else
-            {
-                if (instance == null)
-                {
-                    throw new ArgumentNullException();
-                }
+                throw new ArgumentException(string.Format("{0} is not static", m));
             }
 
-            // ToDo: CreateDelegate
-            Action<A0> callback=
-            (a0) => {
-                m.Invoke(instance, new object[]{ a0 });
+            return (a0) =>
+            {
+                m.Invoke(null, new object[] { a0 });
             };
-            return callback;
         }
 
 
-        public static Action<A0, A1> CreateActionBindThis<S, A0, A1>(MethodInfo m, S instance)
+        public static Action<A0, A1> StaticAction<A0, A1>(MethodInfo m)
         {
-            if (m.IsStatic)
+            if (!m.IsStatic)
             {
-                if (instance != null)
-                {
-                    throw new ArgumentException();
-                }
-            }
-            else
-            {
-                if (instance == null)
-                {
-                    throw new ArgumentNullException();
-                }
+                throw new ArgumentException(string.Format("{0} is not static", m));
             }
 
-            // ToDo: CreateDelegate
-            Action<A0, A1> callback=
-            (a0, a1) => {
-                m.Invoke(instance, new object[]{ a0, a1 });
+            return (a0, a1) =>
+            {
+                m.Invoke(null, new object[] { a0, a1 });
             };
-            return callback;
         }
 
 
-        public static Action<A0, A1, A2> CreateActionBindThis<S, A0, A1, A2>(MethodInfo m, S instance)
+        public static Action<A0, A1, A2> StaticAction<A0, A1, A2>(MethodInfo m)
         {
-            if (m.IsStatic)
+            if (!m.IsStatic)
             {
-                if (instance != null)
-                {
-                    throw new ArgumentException();
-                }
-            }
-            else
-            {
-                if (instance == null)
-                {
-                    throw new ArgumentNullException();
-                }
+                throw new ArgumentException(string.Format("{0} is not static", m));
             }
 
-            // ToDo: CreateDelegate
-            Action<A0, A1, A2> callback=
-            (a0, a1, a2) => {
-                m.Invoke(instance, new object[]{ a0, a1, a2 });
+            return (a0, a1, a2) =>
+            {
+                m.Invoke(null, new object[] { a0, a1, a2 });
             };
-            return callback;
         }
 
 
-        public static Action<A0, A1, A2, A3> CreateActionBindThis<S, A0, A1, A2, A3>(MethodInfo m, S instance)
+        public static Action<A0, A1, A2, A3> StaticAction<A0, A1, A2, A3>(MethodInfo m)
+        {
+            if (!m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is not static", m));
+            }
+
+            return (a0, a1, a2, a3) =>
+            {
+                m.Invoke(null, new object[] { a0, a1, a2, a3 });
+            };
+        }
+
+//////////// OpenAction
+
+        public static Action<S, A0> OpenAction<S, A0>(MethodInfo m)
         {
             if (m.IsStatic)
             {
-                if (instance != null)
-                {
-                    throw new ArgumentException();
-                }
-            }
-            else
-            {
-                if (instance == null)
-                {
-                    throw new ArgumentNullException();
-                }
+                throw new ArgumentException(string.Format("{0} is static", m));
             }
 
-            // ToDo: CreateDelegate
-            Action<A0, A1, A2, A3> callback=
-            (a0, a1, a2, a3) => {
-                m.Invoke(instance, new object[]{ a0, a1, a2, a3 });
+            return (s, a0) =>
+            {
+                m.Invoke(s, new object[] { a0 });
             };
-            return callback;
+        }
+
+
+        public static Action<S, A0, A1> OpenAction<S, A0, A1>(MethodInfo m)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (s, a0, a1) =>
+            {
+                m.Invoke(s, new object[] { a0, a1 });
+            };
+        }
+
+
+        public static Action<S, A0, A1, A2> OpenAction<S, A0, A1, A2>(MethodInfo m)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (s, a0, a1, a2) =>
+            {
+                m.Invoke(s, new object[] { a0, a1, a2 });
+            };
+        }
+
+//////////// BindAction
+
+        public static Action<A0> BindAction<S, A0>(MethodInfo m, S instance)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (a0) =>
+            {
+                m.Invoke(instance, new object[] { a0 });
+            };
+        }
+
+
+        public static Action<A0, A1> BindAction<S, A0, A1>(MethodInfo m, S instance)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (a0, a1) =>
+            {
+                m.Invoke(instance, new object[] { a0, a1 });
+            };
+        }
+
+
+        public static Action<A0, A1, A2> BindAction<S, A0, A1, A2>(MethodInfo m, S instance)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (a0, a1, a2) =>
+            {
+                m.Invoke(instance, new object[] { a0, a1, a2 });
+            };
+        }
+
+
+        public static Action<A0, A1, A2, A3> BindAction<S, A0, A1, A2, A3>(MethodInfo m, S instance)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (a0, a1, a2, a3) =>
+            {
+                m.Invoke(instance, new object[] { a0, a1, a2, a3 });
+            };
+        }
+
+//////////// StaticFunc
+
+        public static Func<A0, T> StaticFunc<A0, T>(MethodInfo m)
+        {
+            if (!m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is not static", m));
+            }
+
+            return (a0) => (T)m.Invoke(null, new object[] { a0 });
+        }
+
+
+        public static Func<A0, A1, T> StaticFunc<A0, A1, T>(MethodInfo m)
+        {
+            if (!m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is not static", m));
+            }
+
+            return (a0, a1) => (T)m.Invoke(null, new object[] { a0, a1 });
+        }
+
+
+        public static Func<A0, A1, A2, T> StaticFunc<A0, A1, A2, T>(MethodInfo m)
+        {
+            if (!m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is not static", m));
+            }
+
+            return (a0, a1, a2) => (T)m.Invoke(null, new object[] { a0, a1, a2 });
+        }
+
+
+        public static Func<A0, A1, A2, A3, T> StaticFunc<A0, A1, A2, A3, T>(MethodInfo m)
+        {
+            if (!m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is not static", m));
+            }
+
+            return (a0, a1, a2, a3) => (T)m.Invoke(null, new object[] { a0, a1, a2, a3 });
+        }
+
+//////////// OpenFunc
+
+        public static Func<S, A0, T> OpenFunc<S, A0, T>(MethodInfo m)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (s, a0) => (T)m.Invoke(s, new object[] { a0 });
+        }
+
+
+        public static Func<S, A0, A1, T> OpenFunc<S, A0, A1, T>(MethodInfo m)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (s, a0, a1) => (T)m.Invoke(s, new object[] { a0, a1 });
+        }
+
+
+        public static Func<S, A0, A1, A2, T> OpenFunc<S, A0, A1, A2, T>(MethodInfo m)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (s, a0, a1, a2) => (T)m.Invoke(s, new object[] { a0, a1, a2 });
+        }
+
+//////////// BindFunc
+
+        public static Func<A0, T> BindFunc<S, A0, T>(MethodInfo m, S instance)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (a0) => (T)m.Invoke(instance, new object[] { a0 });
+        }
+
+
+        public static Func<A0, A1, T> BindFunc<S, A0, A1, T>(MethodInfo m, S instance)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (a0, a1) => (T)m.Invoke(instance, new object[] { a0, a1 });
+        }
+
+
+        public static Func<A0, A1, A2, T> BindFunc<S, A0, A1, A2, T>(MethodInfo m, S instance)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (a0, a1, a2) => (T)m.Invoke(instance, new object[] { a0, a1, a2 });
+        }
+
+
+        public static Func<A0, A1, A2, A3, T> BindFunc<S, A0, A1, A2, A3, T>(MethodInfo m, S instance)
+        {
+            if (m.IsStatic)
+            {
+                throw new ArgumentException(string.Format("{0} is static", m));
+            }
+
+            return (a0, a1, a2, a3) => (T)m.Invoke(instance, new object[] { a0, a1, a2, a3 });
         }
 
 

--- a/Assets/VRM/UniJSON/Scripts/GenericCallUtility/GenericInvokeCallFactory.g.cs
+++ b/Assets/VRM/UniJSON/Scripts/GenericCallUtility/GenericInvokeCallFactory.g.cs
@@ -17,10 +17,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is not static", m));
             }
 
-            return (a0) =>
-            {
-                m.Invoke(null, new object[] { a0 });
-            };
+            return (Action<A0>)Delegate.CreateDelegate(typeof(Action<A0>), null, m);
         }
 
 
@@ -31,10 +28,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is not static", m));
             }
 
-            return (a0, a1) =>
-            {
-                m.Invoke(null, new object[] { a0, a1 });
-            };
+            return (Action<A0, A1>)Delegate.CreateDelegate(typeof(Action<A0, A1>), null, m);
         }
 
 
@@ -45,10 +39,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is not static", m));
             }
 
-            return (a0, a1, a2) =>
-            {
-                m.Invoke(null, new object[] { a0, a1, a2 });
-            };
+            return (Action<A0, A1, A2>)Delegate.CreateDelegate(typeof(Action<A0, A1, A2>), null, m);
         }
 
 
@@ -59,10 +50,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is not static", m));
             }
 
-            return (a0, a1, a2, a3) =>
-            {
-                m.Invoke(null, new object[] { a0, a1, a2, a3 });
-            };
+            return (Action<A0, A1, A2, A3>)Delegate.CreateDelegate(typeof(Action<A0, A1, A2, A3>), null, m);
         }
 
 //////////// OpenAction
@@ -74,10 +62,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is static", m));
             }
 
-            return (s, a0) =>
-            {
-                m.Invoke(s, new object[] { a0 });
-            };
+            return (Action<S, A0>)Delegate.CreateDelegate(typeof(Action<S, A0>), m);
         }
 
 
@@ -88,10 +73,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is static", m));
             }
 
-            return (s, a0, a1) =>
-            {
-                m.Invoke(s, new object[] { a0, a1 });
-            };
+            return (Action<S, A0, A1>)Delegate.CreateDelegate(typeof(Action<S, A0, A1>), m);
         }
 
 
@@ -102,10 +84,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is static", m));
             }
 
-            return (s, a0, a1, a2) =>
-            {
-                m.Invoke(s, new object[] { a0, a1, a2 });
-            };
+            return (Action<S, A0, A1, A2>)Delegate.CreateDelegate(typeof(Action<S, A0, A1, A2>), m);
         }
 
 //////////// BindAction
@@ -117,10 +96,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is static", m));
             }
 
-            return (a0) =>
-            {
-                m.Invoke(instance, new object[] { a0 });
-            };
+            return (Action<A0>)Delegate.CreateDelegate(typeof(Action<A0>), instance, m);
         }
 
 
@@ -131,10 +107,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is static", m));
             }
 
-            return (a0, a1) =>
-            {
-                m.Invoke(instance, new object[] { a0, a1 });
-            };
+            return (Action<A0, A1>)Delegate.CreateDelegate(typeof(Action<A0, A1>), instance, m);
         }
 
 
@@ -145,10 +118,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is static", m));
             }
 
-            return (a0, a1, a2) =>
-            {
-                m.Invoke(instance, new object[] { a0, a1, a2 });
-            };
+            return (Action<A0, A1, A2>)Delegate.CreateDelegate(typeof(Action<A0, A1, A2>), instance, m);
         }
 
 
@@ -159,10 +129,7 @@ namespace UniJSON
                 throw new ArgumentException(string.Format("{0} is static", m));
             }
 
-            return (a0, a1, a2, a3) =>
-            {
-                m.Invoke(instance, new object[] { a0, a1, a2, a3 });
-            };
+            return (Action<A0, A1, A2, A3>)Delegate.CreateDelegate(typeof(Action<A0, A1, A2, A3>), instance, m);
         }
 
 //////////// StaticFunc

--- a/Assets/VRM/UniJSON/Scripts/GenericCallUtility/GenericInvokeCallFactory.g.cs
+++ b/Assets/VRM/UniJSON/Scripts/GenericCallUtility/GenericInvokeCallFactory.g.cs
@@ -8,9 +8,9 @@ namespace UniJSON
     public static partial class GenericInvokeCallFactory
     {
 
-//////////// Create
+//////////// CreateAction
 
-        public static Action<S, A0> Create<S, A0>(MethodInfo m)
+        public static Action<S, A0> CreateAction<S, A0>(MethodInfo m)
         {
             Action<S, A0> callback = null;
             if (m.IsStatic)
@@ -31,7 +31,7 @@ namespace UniJSON
         }
 
 
-        public static Action<S, A0, A1> Create<S, A0, A1>(MethodInfo m)
+        public static Action<S, A0, A1> CreateAction<S, A0, A1>(MethodInfo m)
         {
             Action<S, A0, A1> callback = null;
             if (m.IsStatic)
@@ -52,7 +52,7 @@ namespace UniJSON
         }
 
 
-        public static Action<S, A0, A1, A2> Create<S, A0, A1, A2>(MethodInfo m)
+        public static Action<S, A0, A1, A2> CreateAction<S, A0, A1, A2>(MethodInfo m)
         {
             Action<S, A0, A1, A2> callback = null;
             if (m.IsStatic)
@@ -74,7 +74,7 @@ namespace UniJSON
 
 //////////// CreateWithThis
 
-        public static Action<A0> CreateWithThis<S, A0>(MethodInfo m, S instance)
+        public static Action<A0> CreateActionBindThis<S, A0>(MethodInfo m, S instance)
         {
             if (m.IsStatic)
             {
@@ -100,7 +100,7 @@ namespace UniJSON
         }
 
 
-        public static Action<A0, A1> CreateWithThis<S, A0, A1>(MethodInfo m, S instance)
+        public static Action<A0, A1> CreateActionBindThis<S, A0, A1>(MethodInfo m, S instance)
         {
             if (m.IsStatic)
             {
@@ -126,7 +126,7 @@ namespace UniJSON
         }
 
 
-        public static Action<A0, A1, A2> CreateWithThis<S, A0, A1, A2>(MethodInfo m, S instance)
+        public static Action<A0, A1, A2> CreateActionBindThis<S, A0, A1, A2>(MethodInfo m, S instance)
         {
             if (m.IsStatic)
             {
@@ -152,7 +152,7 @@ namespace UniJSON
         }
 
 
-        public static Action<A0, A1, A2, A3> CreateWithThis<S, A0, A1, A2, A3>(MethodInfo m, S instance)
+        public static Action<A0, A1, A2, A3> CreateActionBindThis<S, A0, A1, A2, A3>(MethodInfo m, S instance)
         {
             if (m.IsStatic)
             {

--- a/Assets/VRM/UniJSON/Scripts/GenericCast.cs
+++ b/Assets/VRM/UniJSON/Scripts/GenericCast.cs
@@ -56,10 +56,7 @@ namespace UniJSON
             }
             else
             {
-                return (Func<S, T>)((S s) =>
-                {
-                    return (T)mi.Invoke(null, new object[] { s });
-                });
+                return GenericInvokeCallFactory.StaticFunc<S, T>(mi);
             }
         }
 

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonArrayValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonArrayValidator.cs
@@ -264,7 +264,7 @@ namespace UniJSON
                         IFormatter, 
                         JsonSchemaValidationContext, 
                         T>)
-                        GenericInvokeCallFactory.Create<
+                        GenericInvokeCallFactory.CreateAction<
                             IJsonSchemaValidator, 
                             IFormatter, 
                             JsonSchemaValidationContext, 

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonArrayValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonArrayValidator.cs
@@ -264,7 +264,7 @@ namespace UniJSON
                         IFormatter, 
                         JsonSchemaValidationContext, 
                         T>)
-                        GenericInvokeCallFactory.CreateAction<
+                        GenericInvokeCallFactory.StaticAction<
                             IJsonSchemaValidator, 
                             IFormatter, 
                             JsonSchemaValidationContext, 

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonEnumValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonEnumValidator.cs
@@ -319,9 +319,11 @@ namespace UniJSON
                         var mi = typeof(Enum).GetMethods(BindingFlags.Static | BindingFlags.Public).First(
                             x => x.Name == "Parse" && x.GetParameters().Length == 3
                             );
+
+                        var enumParse = GenericInvokeCallFactory.StaticFunc<Type, string, bool, object>(mi);
                         s_d = x =>
                         {
-                            var enumValue = mi.Invoke(null, new object[] { typeof(U), x.GetString(), true });
+                            var enumValue = enumParse(typeof(U), x.GetString(), true);
                             return GenericCast<object, U>.Cast(enumValue);
                         };
                     }

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonObjectValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonObjectValidator.cs
@@ -338,7 +338,7 @@ namespace UniJSON
                         BindingFlags.Static | BindingFlags.NonPublic)
                         ;
                     var g = mi.MakeGenericMethod(fi.FieldType);
-                    return (FieldValidator)g.Invoke(null, new object[] { fi });
+                    return GenericInvokeCallFactory.StaticFunc<FieldInfo, FieldValidator>(g)(fi);
                 }
 
                 static FieldValidator _CreateFieldValidator<U>(FieldInfo fi)
@@ -498,7 +498,7 @@ namespace UniJSON
                     var mi = typeof(Serializer).GetMethod("_CreateFieldSerializer",
                         BindingFlags.Static | BindingFlags.NonPublic);
                     var g = mi.MakeGenericMethod(fi.FieldType);
-                    return (FieldSerializer)g.Invoke(null, new object[] { fi });
+                    return GenericInvokeCallFactory.StaticFunc<FieldInfo, FieldSerializer>(g)(fi);
                 }
 
                 static FieldSerializer _CreateFieldSerializer<U>(FieldInfo fi)

--- a/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonObjectValidator.cs
+++ b/Assets/VRM/UniJSON/Scripts/JsonSchemaValidator/JsonObjectValidator.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
+
 
 namespace UniJSON
 {
@@ -306,27 +306,13 @@ namespace UniJSON
             }
 
             public static void CreateFieldProcessors<G, D>(
-                string methodName,
+                Func<FieldInfo, D> creator,
                 Dictionary<string, D> processors
                 )
             {
-                var mi = typeof(G).GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
-
-                var t = typeof(T);
                 foreach (var fi in GetFields())
                 {
-                    var value = Expression.Parameter(t, "value");
-                    var fieldValue = Expression.Field(value, fi);
-                    var compileld = Expression.Lambda(fieldValue, value).Compile();
-
-                    var getter = Expression.Constant(compileld);
-                    var name = Expression.Constant(fi.Name);
-
-                    var g = mi.MakeGenericMethod(fi.FieldType);
-                    var call = Expression.Call(g, getter, name);
-                    var lambda = (Func<D>)Expression.Lambda(call).Compile();
-
-                    processors.Add(fi.Name, lambda());
+                    processors.Add(fi.Name, creator(fi));
                 }
             }
         }
@@ -346,12 +332,23 @@ namespace UniJSON
 
                 Dictionary<string, FieldValidator> m_validators;
 
-                static FieldValidator CreateFieldValidator<U>(Func<T, U> getter, string name)
+                static FieldValidator CreateFieldValidator(FieldInfo fi)
                 {
+                    var mi = typeof(ObjectValidator).GetMethod("_CreateFieldValidator",
+                        BindingFlags.Static | BindingFlags.NonPublic)
+                        ;
+                    var g = mi.MakeGenericMethod(fi.FieldType);
+                    return (FieldValidator)g.Invoke(null, new object[] { fi });
+                }
+
+                static FieldValidator _CreateFieldValidator<U>(FieldInfo fi)
+                {
+                    var getter = (Func<T, U>)((t) => (U)fi.GetValue(t));
+
                     return (JsonSchema s, JsonSchemaValidationContext c, T o, out bool isIgnorable) =>
                     {
                         var v = s.Validator;
-                        using (c.Push(name))
+                        using (c.Push(fi.Name))
                         {
                             var field = getter(o);
                             var ex = v.Validate(c, field);
@@ -367,7 +364,7 @@ namespace UniJSON
                 {
                     var validators = new Dictionary<string, FieldValidator>();
                     GenericFieldView<T>.CreateFieldProcessors<ObjectValidator, FieldValidator>(
-                        "CreateFieldValidator", validators);
+                        CreateFieldValidator, validators);
 
                     m_validators = validators;
                 }
@@ -496,14 +493,27 @@ namespace UniJSON
 
                 Dictionary<string, FieldSerializer> m_serializers;
 
-                static FieldSerializer CreateFieldSerializer<U>(Func<T, U> getter, string name)
+                static FieldSerializer CreateFieldSerializer(FieldInfo fi)
                 {
+                    var mi = typeof(Serializer).GetMethod("_CreateFieldSerializer",
+                        BindingFlags.Static | BindingFlags.NonPublic);
+                    var g = mi.MakeGenericMethod(fi.FieldType);
+                    return (FieldSerializer)g.Invoke(null, new object[] { fi });
+                }
+
+                static FieldSerializer _CreateFieldSerializer<U>(FieldInfo fi)
+                {
+                    Func<T, U> getter = t =>
+                    {
+                        return (U)fi.GetValue(t);
+                    };
+
                     return (s, c, f, o, vRes, deps) =>
                     {
                         var v = s.Validator;
                         var field = getter(o);
 
-                        if (vRes[name].Ex != null)
+                        if (vRes[fi.Name].Ex != null)
                         {
                             return;
                         }
@@ -519,7 +529,7 @@ namespace UniJSON
                             }
                         }
 
-                        f.Key(name);
+                        f.Key(fi.Name);
                         v.Serialize(f, c, field);
                     };
                 }
@@ -528,7 +538,7 @@ namespace UniJSON
                 {
                     var serializers = new Dictionary<string, FieldSerializer>();
                     GenericFieldView<T>.CreateFieldProcessors<Serializer, FieldSerializer>(
-                        "CreateFieldSerializer", serializers);
+                        CreateFieldSerializer, serializers);
 
                     m_serializers = serializers;
                 }

--- a/Assets/VRM/UniJSON/Scripts/ListTreeNode/ListTreeNodeDeserializerExtensions.cs
+++ b/Assets/VRM/UniJSON/Scripts/ListTreeNode/ListTreeNodeDeserializerExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 
 
@@ -30,10 +29,7 @@ namespace UniJSON
                     var mi = typeof(GenericCreator<T, U>).GetMethod("ArrayCreator",
                         BindingFlags.NonPublic | BindingFlags.Static);
                     var g = mi.MakeGenericMethod(t.GetElementType());
-                    var src = Expression.Parameter(typeof(T), "src");
-                    var call = Expression.Call(g, src);
-                    var func = Expression.Lambda(call, src);
-                    return (Func<ListTreeNode<T>, U>)func.Compile();
+                    return GenericInvokeCallFactory.StaticFunc<ListTreeNode<T>, U>(g);
                 }
 
                 {
@@ -180,10 +176,7 @@ namespace UniJSON
 
                 if (mi != null)
                 {
-                    var self = Expression.Parameter(typeof(ListTreeNode<T>), "self");
-                    var call = Expression.Call(self, mi);
-                    var func = Expression.Lambda(call, self);
-                    return (Func<ListTreeNode<T>, U>)func.Compile();
+                    return GenericInvokeCallFactory.StaticFunc<ListTreeNode<T>, U>(mi);
                 }
             }
 
@@ -194,10 +187,7 @@ namespace UniJSON
                 var mi = typeof(GenericDeserializer<T, U>).GetMethod("GenericArrayDeserializer",
                     BindingFlags.Static | BindingFlags.NonPublic);
                 var g = mi.MakeGenericMethod(target.GetElementType());
-                var self = Expression.Parameter(typeof(ListTreeNode<T>), "self");
-                var call = Expression.Call(g, self);
-                var func = Expression.Lambda(call, self);
-                return (Func<ListTreeNode<T>, U>)func.Compile();
+                return GenericInvokeCallFactory.StaticFunc<ListTreeNode<T>, U>(g);
             }
 
             if (target.IsGenericType)
@@ -207,10 +197,7 @@ namespace UniJSON
                     var mi = typeof(GenericDeserializer<T, U>).GetMethod("GenericListDeserializer",
                         BindingFlags.Static | BindingFlags.NonPublic);
                     var g = mi.MakeGenericMethod(target.GetGenericArguments());
-                    var self = Expression.Parameter(typeof(ListTreeNode<T>), "self");
-                    var call = Expression.Call(g, self);
-                    var func = Expression.Lambda(call, self);
-                    return (Func<ListTreeNode<T>, U>)func.Compile();
+                    return GenericInvokeCallFactory.StaticFunc<ListTreeNode<T>, U>(g);
                 }
 
                 if (target.GetGenericTypeDefinition() == typeof(Dictionary<,>) &&
@@ -219,15 +206,7 @@ namespace UniJSON
                     var mi = typeof(ListTreeNodeDeserializerExtensions).GetMethod("DictionaryDeserializer",
                     BindingFlags.Static | BindingFlags.NonPublic);
                     var g = mi.MakeGenericMethod(typeof(T));
-                    var self = Expression.Parameter(typeof(ListTreeNode<T>), "self");
-                    var call = Expression.Call(g, self);
-                    var func = Expression.Lambda(call, self);
-                    var d = (Func<ListTreeNode<T>, object>)func.Compile();
-                    return (ListTreeNode<T> s) =>
-                    {
-                        var x = d(s);
-                        return (U)x;
-                    };
+                    return GenericInvokeCallFactory.StaticFunc<ListTreeNode<T>, U>(g);
                 }
             }
 


### PR DESCRIPTION
#146 

Removed Expression.Compile.
Remove the IFormatter.KeyValue call and it will be completed.
IFormatter.KeyValue is almost in JsonSerializableBase.
