### PR TITLE
Add README.url

### DIFF
--- a/Assets/VRM/README.url
+++ b/Assets/VRM/README.url
@@ -1,0 +1,2 @@
+[InternetShortcut]
+URL=https://github.com/dwango/UniVRM

--- a/Assets/VRM/README.url.meta
+++ b/Assets/VRM/README.url.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b6360e0694ca54c57b83fa6a73e2261a
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
UniVRMはMITライセンスの元配布されているため他のリポジトリなどで再配布される状況があると思うのですが、現状だとインポートされたパッケージ内からREADMEやLICENSを辿る導線が含まれていません。再配布するユーザーに委ねられるべきかもしれませんが、`README.url`という形でリポジトリに飛べる形にしておくと確実だと考えました。

完全な`README.md`を記載するパターン、`LICENSE.txt`も併せて配置するパターンなども考えましたが、それぞれのオリジナルの変更に追従する手間がかかるため、リンクのみを置く形が好ましいと思います。