### PR TITLE
Bump version to 0.51.0. Support Semver

### DIFF
--- a/Assets/VRM/UniVRM/Editor/Format/VRMVersionMenu.cs
+++ b/Assets/VRM/UniVRM/Editor/Format/VRMVersionMenu.cs
@@ -18,8 +18,10 @@ namespace VRM
     {{
         public const int MAJOR = {0};
         public const int MINOR = {1};
+        public const int PATCH = {2};
+        public const string PRE_ID = {3};
 
-        public const string VERSION = ""{0}.{1}"";
+        public const string VERSION = ""{0}.{1}.{2}{4}"";
     }}
 }}
 ";
@@ -29,7 +31,14 @@ namespace VRM
 #endif
         static void IncrementVersion()
         {
-            var source = string.Format(template, VRMVersion.MAJOR, VRMVersion.MINOR + 1);
+            var source = string.Format(
+                template,
+                VRMVersion.MAJOR,
+                VRMVersion.MINOR + 1,
+                VRMVersion.PATCH,
+                VRMVersion.PRE_ID,
+                VRMVersion.PRE_ID != "" ? string.Format("-{0}", VRMVersion.PRE_ID) : ""
+                );
             File.WriteAllText(path, source);
             AssetDatabase.Refresh();
         }
@@ -39,7 +48,14 @@ namespace VRM
 #endif
         static void DecrementVersion()
         {
-            var source = string.Format(template, VRMVersion.MAJOR, VRMVersion.MINOR - 1);
+            var source = string.Format(
+                template,
+                VRMVersion.MAJOR,
+                VRMVersion.MINOR - 1,
+                VRMVersion.PATCH,
+                VRMVersion.PRE_ID,
+                VRMVersion.PRE_ID != "" ? string.Format("-{0}", VRMVersion.PRE_ID) : ""
+                );
             File.WriteAllText(path, source);
             AssetDatabase.Refresh();
         }
@@ -127,7 +143,7 @@ namespace VRM
             var f = new JsonFormatter(4);
             Traverse(parsed, f, dir);
             var json = f.ToString();
-                
+
             var path = dir.Child("vrm.schema.json");
             Debug.LogFormat("write JsonSchema: {0}", path.FullPath);
             File.WriteAllText(path.FullPath, json);

--- a/Assets/VRM/UniVRM/Editor/Tests/VersionTests.cs
+++ b/Assets/VRM/UniVRM/Editor/Tests/VersionTests.cs
@@ -1,0 +1,58 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UniJSON;
+using UnityEngine;
+
+namespace VRM
+{
+	public class UniVRMVersionTests
+	{
+		[Test]
+		[TestCase(VRMVersion.VERSION, false)]
+		[TestCase("0.99", true)]
+		[TestCase("0.99.0", true)]
+		[TestCase("1.0.0", true)]
+		public void IsNewweTest(string newer, bool isNewer)
+		{
+			Assert.AreEqual(isNewer, VRMVersion.IsNewer(newer));
+		}
+
+		[Test]
+		[TestCase("0.50", "0.50", false)]
+		[TestCase("0.50", "0.51.0", false)]
+		[TestCase("0.51.0", "0.50", true)]
+		[TestCase("0.51.0", "0.51.0", false)]
+		[TestCase("0.51.1", "0.51.0", true)]
+		[TestCase("0.51.0", "0.51.0-a", false)]
+		[TestCase("0.51.0-b", "0.51.0-a", true)]
+		[TestCase("1.0.0-a", "0.51.0", true)]
+		[TestCase("1.0.0", "0.51.0", true)]
+		public void IsNewweTest(string newer, string older, bool isNewer)
+		{
+			Assert.AreEqual(isNewer, VRMVersion.IsNewer(newer, older));
+		}
+
+		[Test]
+		[TestCase("0.50", true, 0, 50, 0, "")]
+		[TestCase("0.51.0", true, 0, 51, 0, "")]
+		[TestCase("0.51.1", true, 0, 51, 1, "")]
+		[TestCase("0.51.2-a", true, 0, 51, 2, "a")]
+		[TestCase("0.51.10-a1", true, 0, 51, 10, "a1")]
+		[TestCase("aaaaa", false, 0, 0, 0, "")]
+		public void ParseVersionTest(string version, bool canBeParsed, int major, int minor, int patch, string pre)
+		{
+			VRMVersion.Version v;
+			var res = VRMVersion.ParseVersion(version, out v);
+			Assert.AreEqual(canBeParsed, res);
+			if (res)
+			{
+				Assert.AreEqual(major, v.Major);
+				Assert.AreEqual(minor, v.Minor);
+				Assert.AreEqual(patch, v.Patch);
+				Assert.AreEqual(pre, v.Pre);
+			}
+		}
+	}
+}

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMVersion.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMVersion.cs
@@ -4,8 +4,10 @@ namespace VRM
     public static partial class VRMVersion
     {
         public const int MAJOR = 0;
-        public const int MINOR = 50;
+        public const int MINOR = 51;
+        public const int PATCH = 0;
+        public const string PRE_ID = "";
 
-        public const string VERSION = "0.50";
+        public const string VERSION = "0.51.0";
     }
 }

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMVersionPartial.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMVersionPartial.cs
@@ -1,10 +1,15 @@
-﻿
-using System;
+﻿using System;
+using System.Text.RegularExpressions;
 
 namespace VRM
 {
     public static partial class VRMVersion
     {
+        /// <summary>
+        /// Returns true if a passed version is newer than current UniVRM.
+        /// </summary>
+        /// <param name="version"></param>
+        /// <returns></returns>
         public static bool IsNewer(string version)
         {
             if (string.IsNullOrEmpty(version))
@@ -18,34 +23,80 @@ namespace VRM
                 version = version.Substring(prefix.Length);
             }
 
-            var splited = version.Split('.');
-            if (splited.Length < 2)
+            return IsNewer(version, VERSION);
+        }
+
+        public static bool IsNewer(string newer, string older)
+        {
+            Version newerVersion;
+            if (!ParseVersion(newer, out newerVersion))
             {
                 return false;
             }
 
+            Version olderVersion;
+            if (!ParseVersion(older, out olderVersion))
+            {
+                return false;
+            }
+
+            if (newerVersion.Major > olderVersion.Major)
+            {
+                return true;
+            }
+
+            if (newerVersion.Minor > olderVersion.Minor)
+            {
+                return true;
+            }
+
+            if (newerVersion.Patch > olderVersion.Patch)
+            {
+                return true;
+            }
+
+            if (String.Compare(newerVersion.Pre, olderVersion.Pre) > 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static readonly Regex VersionSpec =
+            new Regex(@"(?<major>\d+)\.(?<minor>\d+)(\.(?<patch>\d+))?(-(?<pre>[0-9A-Za-z-]+))?");
+
+        public static bool ParseVersion(string version, out Version v)
+        {
+            var match = VersionSpec.Match(version);
+            if (!match.Success)
+            {
+                v = new Version();
+                return false;
+            }
+
+            v = new Version();
             try
             {
-                var major = int.Parse(splited[0]);
-                var minor = int.Parse(splited[1]);
+                v.Major = int.Parse(match.Groups["major"].Value);
+                v.Minor = int.Parse(match.Groups["minor"].Value);
+                v.Patch = match.Groups["patch"].Success ? int.Parse(match.Groups["patch"].Value) : 0;
+                v.Pre = match.Groups["pre"].Success ? match.Groups["pre"].Value : "";
 
-                if (major < MAJOR)
-                {
-                    return false;
-                }
-                else if (major > MAJOR)
-                {
-                    return true;
-                }
-                else
-                {
-                    return minor > MINOR;
-                }
+                return true;
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 return false;
             }
+        }
+
+        public struct Version
+        {
+            public int Major;
+            public int Minor;
+            public int Patch;
+            public string Pre;
         }
 
         public const string VRM_VERSION = "UniVRM-" + VERSION;


### PR DESCRIPTION
Bump version to `0.51.0` for the next release. And resolve #182.