### PR TITLE
Add extensions.VRM.specVersion to the json schema

### DIFF
--- a/specification/0.0/schema/vrm.schema.json
+++ b/specification/0.0/schema/vrm.schema.json
@@ -7,6 +7,10 @@
             "description": "Version of exporter that vrm created. UniVRM-0.46",
             "type": "string"
         },
+        "specVersion": {
+            "description": "Version of VRM specification. 0.0",
+            "type": "string"
+        },
         "meta": {
             "$ref": "vrm.meta.schema.json"
         },


### PR DESCRIPTION
specVersionの記述がjson schemaに存在しなかったため、記述を追加しました。