### PR TITLE
Fix alpha issue when UniUnlit material is opaque.

### DIFF
--- a/Assets/VRM/UniUnlit/Resources/UniUnlit.shader
+++ b/Assets/VRM/UniUnlit/Resources/UniUnlit.shader
@@ -86,6 +86,10 @@
                     clip(col.a - _Cutoff);
                 #endif
                 
+                #if !defined(_ALPHATEST_ON) && !defined(_ALPHABLEND_ON)
+                    col.a = 1.0;
+                #endif
+                
                 UNITY_APPLY_FOG(i.fogCoord, col);
                 return col;
             }


### PR DESCRIPTION
問題
- UniUnlit マテリアルが Opaque であるにも関わらず、アルファに 1.0 以外の値が書き込まれている

解決
- Opaque のときはアルファ 1.0 を出力