### PR TITLE
Bake smoothness and roughnessFactor into textures. 

### DIFF
--- a/Assets/VRM/UniGLTF/Editor/Tests/TextureTests.cs
+++ b/Assets/VRM/UniGLTF/Editor/Tests/TextureTests.cs
@@ -31,4 +31,99 @@ namespace UniGLTF
             Assert.AreEqual(glFilter.LINEAR_MIPMAP_LINEAR, sampler.magFilter);
         }
     }
+
+    public class MetallicRoughnessConverterTests
+    {
+        [Test]
+        public void ExportingColorTest()
+        {
+            {
+                var smoothness = 1.0f;
+                var conv = new MetallicRoughnessConverter(smoothness);
+                Assert.That(
+                    conv.Export(new Color32(255, 255, 255, 255)),
+                    // r <- 0   : (Unused)
+                    // g <- 0   : ((1 - s.a(as float) * smoothness) ^ 2)(as int8)
+                    // b <- 255 : Same metallic (src.r)
+                    // a <- 255 : (Unused)
+                    Is.EqualTo(new Color32(0, 0, 255, 255)));
+            }
+
+            {
+                var smoothness = 0.5f;
+                var conv = new MetallicRoughnessConverter(smoothness);
+                Assert.That(
+                    conv.Export(new Color32(255, 255, 255, 255)),
+                    // r <- 0   : (Unused)
+                    // g <- 63  : ((1 - s.a(as float) * smoothness) ^ 2)(as int8)
+                    // b <- 255 : Same metallic (src.r)
+                    // a <- 255 : (Unused)
+                    Is.EqualTo(new Color32(0, 63, 255, 255)));
+            }
+
+            {
+                var smoothness = 0.0f;
+                var conv = new MetallicRoughnessConverter(smoothness);
+                Assert.That(
+                    conv.Export(new Color32(255, 255, 255, 255)),
+                    // r <- 0   : (Unused)
+                    // g <- 255 : ((1 - s.a(as float) * smoothness) ^ 2)(as int8)
+                    // b <- 255 : Same metallic (src.r)
+                    // a <- 255 : (Unused)
+                    Is.EqualTo(new Color32(0, 255, 255, 255)));
+            }
+        }
+
+        [Test]
+        public void ImportingColorTest()
+        {
+            {
+                var roughnessFactor = 1.0f;
+                var conv = new MetallicRoughnessConverter(roughnessFactor);
+                Assert.That(
+                    conv.Import(new Color32(255, 255, 255, 255)),
+                    // r <- 255 : Same metallic (src.r)
+                    // g <- 0   : (Unused)
+                    // b <- 0   : (Unused)
+                    // a <- 255 : ((1 - sqrt(s.g(as float) * roughnessFactor)))(as int8)
+                    Is.EqualTo(new Color32(255, 0, 0, 0)));
+            }
+
+            {
+                var roughnessFactor = 1.0f;
+                var conv = new MetallicRoughnessConverter(roughnessFactor);
+                Assert.That(
+                    conv.Import(new Color32(255, 63, 255, 255)),
+                    // r <- 255 : Same metallic (src.r)
+                    // g <- 0   : (Unused)
+                    // b <- 0   : (Unused)
+                    // a <- 255 : ((1 - sqrt(s.g(as float) * roughnessFactor)))(as int8)
+                    Is.EqualTo(new Color32(255, 0, 0, 128))); // smoothness 0.5 * src.a 1.0
+            }
+
+            {
+                var roughnessFactor = 0.5f;
+                var conv = new MetallicRoughnessConverter(roughnessFactor);
+                Assert.That(
+                    conv.Import(new Color32(255, 255, 255, 255)),
+                    // r <- 255 : Same metallic (src.r)
+                    // g <- 0   : (Unused)
+                    // b <- 0   : (Unused)
+                    // a <- 255 : ((1 - sqrt(s.g(as float) * roughnessFactor)))(as int8)
+                    Is.EqualTo(new Color32(255, 0, 0, 74)));
+            }
+
+            {
+                var roughnessFactor = 0.0f;
+                var conv = new MetallicRoughnessConverter(roughnessFactor);
+                Assert.That(
+                    conv.Import(new Color32(255, 255, 255, 255)),
+                    // r <- 255 : Same metallic (src.r)
+                    // g <- 0   : (Unused)
+                    // b <- 0   : (Unused)
+                    // a <- 255 : ((1 - sqrt(s.g(as float) * roughnessFactor)))(as int8)
+                    Is.EqualTo(new Color32(255, 0, 0, 255)));
+            }
+        }
+    }
 }

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
@@ -86,7 +86,8 @@ namespace UniGLTF
                 // Set 1.0f as hard-coded. See: https://github.com/dwango/UniVRM/issues/212.
                 material.pbrMetallicRoughness.roughnessFactor = 1.0f;
             }
-            else {
+            else
+            {
                 if (m.HasProperty("_Metallic"))
                 {
                     material.pbrMetallicRoughness.metallicFactor = m.GetFloat("_Metallic");
@@ -97,8 +98,6 @@ namespace UniGLTF
                     material.pbrMetallicRoughness.roughnessFactor = 1.0f - m.GetFloat("_Glossiness");
                 }
             }
-
-
         }
 
         static void Export_Normal(Material m, TextureExportManager textureManager, glTFMaterial material)

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialExporter.cs
@@ -61,33 +61,44 @@ namespace UniGLTF
             int index = -1;
             if (m.HasProperty("_MetallicGlossMap"))
             {
-                index = textureManager.ConvertAndGetIndex(m.GetTexture("_MetallicGlossMap"), new MetallicRoughnessConverter());
+                float smoothness = 0.0f;
+                if (m.HasProperty("_GlossMapScale"))
+                {
+                    smoothness = m.GetFloat("_GlossMapScale");
+                }
+
+                // Bake smoothness values into a texture.
+                var converter = new MetallicRoughnessConverter(smoothness);
+                index = textureManager.ConvertAndGetIndex(m.GetTexture("_MetallicGlossMap"), converter);
                 if (index != -1)
                 {
-                    material.pbrMetallicRoughness.metallicRoughnessTexture = new glTFMaterialMetallicRoughnessTextureInfo()
-                    {
-                        index = index,
-                    };
+                    material.pbrMetallicRoughness.metallicRoughnessTexture =
+                        new glTFMaterialMetallicRoughnessTextureInfo()
+                        {
+                            index = index,
+                        };
                 }
             }
 
-            if (index != -1 && m.HasProperty("_GlossMapScale"))
+            if (index != -1)
             {
                 material.pbrMetallicRoughness.metallicFactor = 1.0f;
-                material.pbrMetallicRoughness.roughnessFactor = 1.0f - m.GetFloat("_GlossMapScale");
+                // Set 1.0f as hard-coded. See: https://github.com/dwango/UniVRM/issues/212.
+                material.pbrMetallicRoughness.roughnessFactor = 1.0f;
             }
-            else
-            {
+            else {
                 if (m.HasProperty("_Metallic"))
                 {
                     material.pbrMetallicRoughness.metallicFactor = m.GetFloat("_Metallic");
                 }
+
                 if (m.HasProperty("_Glossiness"))
                 {
                     material.pbrMetallicRoughness.roughnessFactor = 1.0f - m.GetFloat("_Glossiness");
                 }
-
             }
+
+
         }
 
         static void Export_Normal(Material m, TextureExportManager textureManager, glTFMaterial material)

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
@@ -164,11 +164,14 @@ namespace UniGLTF
                     if (texture != null)
                     {
                         var prop = "_MetallicGlossMap";
-                        material.SetTexture(prop, texture.ConvertTexture(prop));
+                        var smoothness = 1.0f - x.pbrMetallicRoughness.roughnessFactor;
+                        // Bake smoothness values into a texture.
+                        material.SetTexture(prop, texture.ConvertTexture(prop, smoothness));
                     }
 
                     material.SetFloat("_Metallic", 1.0f);
-                    material.SetFloat("_GlossMapScale", 1.0f - x.pbrMetallicRoughness.roughnessFactor);
+                    // Set 1.0f as hard-coded. See: https://github.com/dwango/UniVRM/issues/212.
+                    material.SetFloat("_GlossMapScale", 1.0f);
                 }
                 else
                 {

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
@@ -164,9 +164,8 @@ namespace UniGLTF
                     if (texture != null)
                     {
                         var prop = "_MetallicGlossMap";
-                        var smoothness = 1.0f - x.pbrMetallicRoughness.roughnessFactor;
-                        // Bake smoothness values into a texture.
-                        material.SetTexture(prop, texture.ConvertTexture(prop, smoothness));
+                        // Bake roughnessFactor values into a texture.
+                        material.SetTexture(prop, texture.ConvertTexture(prop, x.pbrMetallicRoughness.roughnessFactor));
                     }
 
                     material.SetFloat("_Metallic", 1.0f);

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureConverter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureConverter.cs
@@ -47,7 +47,7 @@ namespace UniGLTF
         }
     }
 
-    class MetallicRoughnessConverter : ITextureConverter
+    public class MetallicRoughnessConverter : ITextureConverter
     {
         private const string m_extension = ".metallicRoughness";
 
@@ -77,7 +77,7 @@ namespace UniGLTF
             // Roughness(glTF): dst.g -> Smoothness(Unity): src.a (with conversion)
             // Metallic(glTF) : dst.b -> Metallic(Unity)  : src.r
 
-            var pixelRoughnessFactor = src.g * _smoothnessOrRoughness; // roughness
+            var pixelRoughnessFactor = (src.g * _smoothnessOrRoughness) / 255.0f; // roughness
             var pixelSmoothness = 1.0f - Mathf.Sqrt(pixelRoughnessFactor);
 
             return new Color32
@@ -96,9 +96,10 @@ namespace UniGLTF
             // Smoothness(Unity): src.a -> Roughness(glTF): dst.g (with conversion)
             // Metallic(Unity)  : src.r -> Metallic(glTF) : dst.b
 
-            var pixelSmoothness = src.a * _smoothnessOrRoughness; // smoothness
+            var pixelSmoothness = (src.a * _smoothnessOrRoughness) / 255.0f; // smoothness
             // https://blogs.unity3d.com/jp/2016/01/25/ggx-in-unity-5-3/
-            var pixelRoughnessFactor = (1.0f - pixelSmoothness) * (1.0f - pixelSmoothness);
+            var pixelRoughnessFactorSqrt = (1.0f - pixelSmoothness);
+            var pixelRoughnessFactor = pixelRoughnessFactorSqrt * pixelRoughnessFactorSqrt;
 
             return new Color32
             {
@@ -112,7 +113,7 @@ namespace UniGLTF
         }
     }
 
-    class NormalConverter : ITextureConverter
+    public class NormalConverter : ITextureConverter
     {
         private const string m_extension = ".normal";
 
@@ -157,7 +158,7 @@ namespace UniGLTF
         }
     }
 
-    class OcclusionConverter : ITextureConverter
+    public class OcclusionConverter : ITextureConverter
     {
         private const string m_extension = ".occlusion";
 

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
@@ -36,7 +36,7 @@ namespace UniGLTF
         /// <param name="prop"></param>
         /// <param name="smoothness">used only when converting MetallicRoughness maps</param>
         /// <returns></returns>
-        public Texture2D ConvertTexture(string prop, float smoothness = 1.0f)
+        public Texture2D ConvertTexture(string prop, float smoothnessOrRoughness = 1.0f)
         {
             var convertedTexture = Converts.FirstOrDefault(x => x.Key == prop);
             if (convertedTexture.Value != null)
@@ -69,7 +69,7 @@ namespace UniGLTF
 
             if (prop == "_MetallicGlossMap")
             {
-                var converted = new MetallicRoughnessConverter(smoothness).GetImportTexture(Texture);
+                var converted = new MetallicRoughnessConverter(smoothnessOrRoughness).GetImportTexture(Texture);
                 m_converts.Add(prop, converted);
                 return converted;
             }

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
@@ -30,7 +30,13 @@ namespace UniGLTF
             get { return m_converts; }
         }
 
-        public Texture2D ConvertTexture(string prop)
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <param name="smoothness">used only when converting MetallicRoughness maps</param>
+        /// <returns></returns>
+        public Texture2D ConvertTexture(string prop, float smoothness = 1.0f)
         {
             var convertedTexture = Converts.FirstOrDefault(x => x.Key == prop);
             if (convertedTexture.Value != null)
@@ -63,7 +69,7 @@ namespace UniGLTF
 
             if (prop == "_MetallicGlossMap")
             {
-                var converted = new MetallicRoughnessConverter().GetImportTexture(Texture);
+                var converted = new MetallicRoughnessConverter(smoothness).GetImportTexture(Texture);
                 m_converts.Add(prop, converted);
                 return converted;
             }


### PR DESCRIPTION
Resolve #212.

Now some conversion logic are introduced when converting MetallicRoughness maps.

- Unity world to glTF world
  - Now `smoothness` value is baked into exported textures when exporting
  - Thus `roughnessFactor` is hard-coded as `1.0f` in glTF (because this values are already baked into textures)

- glTF world to Unity world
  - (vice versa)
  - Now `roughnessFactor` value is baked into imported textures when importing
  - Thus `smoothness` is hard-coded as `1.0f` in Unity (because this values are already baked into textures)