### PR TITLE
Replace base libraries for loading/saving glTF and VRM formats

### DIFF
--- a/Assets/VRM/UniGLTF/Editor/Tests/MaterialTests.cs
+++ b/Assets/VRM/UniGLTF/Editor/Tests/MaterialTests.cs
@@ -170,7 +170,7 @@ namespace UniGLTF
             var materialImporter = new MaterialImporter(shaderStore, null);
 
             {
-                var material = materialImporter.CreateMaterial(0, new glTFMaterial
+                var material = materialImporter.CreateMaterial(0, new VGltf.Types.Material
                 {
 
                 });

--- a/Assets/VRM/UniGLTF/Editor/Tests/UniGLTF.Editor.Tests.asmdef
+++ b/Assets/VRM/UniGLTF/Editor/Tests/UniGLTF.Editor.Tests.asmdef
@@ -2,7 +2,9 @@
     "name": "UniGLTF.Editor.Tests",
     "references": [
         "VRM",
-        "UniJSON"
+        "UniJSON",
+        "VJson",
+        "VGltf"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/Assets/VRM/UniGLTF/Editor/Tests/UniGLTFTests.cs
+++ b/Assets/VRM/UniGLTF/Editor/Tests/UniGLTFTests.cs
@@ -685,7 +685,9 @@ namespace UniGLTF
                 // import
                 {
                     var context = new ImporterContext();
-                    context.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
+                    context.ParseJson(json, new VGltf.Glb.StoredBuffer {
+                            Payload = new ArraySegment<byte>(new byte[1024 * 1024]),
+                    });
                     //Debug.LogFormat("{0}", context.Json);
                     context.Load();
 
@@ -706,7 +708,9 @@ namespace UniGLTF
                     {
                         UseUniJSONParser = true
                     };
-                    context.ParseJson(json, new SimpleStorage(new ArraySegment<byte>(new byte[1024 * 1024])));
+                    context.ParseJson(json, new VGltf.Glb.StoredBuffer {
+                            Payload = new ArraySegment<byte>(new byte[1024 * 1024]),
+                    });
                     //Debug.LogFormat("{0}", context.Json);
                     context.Load();
 

--- a/Assets/VRM/UniGLTF/Editor/Tests/UniGLTFTests.cs
+++ b/Assets/VRM/UniGLTF/Editor/Tests/UniGLTFTests.cs
@@ -174,6 +174,29 @@ namespace UniGLTF
             };
             var json2 = JsonSchema.FromType<glTFMesh>().Serialize(model, c);
             Assert.AreEqual(@"{""name"":""mesh"",""primitives"":[{""mode"":0,""attributes"":{""POSITION"":0},""material"":0}]}", json2);
+
+
+            // New models
+            {
+                var m = new VGltf.Types.Mesh {
+                    Name = "mesh",
+                    Primitives = new List<VGltf.Types.Mesh.PrimitiveType>
+                    {
+                        new VGltf.Types.Mesh.PrimitiveType
+                        {
+                            Attributes = new Dictionary<string, int> {
+                                {"POSITION", 0},
+                            },
+                        }
+                    },
+                };
+                var schema = VJson.Schema.JsonSchemaAttribute.CreateFromType(m.GetType());
+                Assert.Null(VJson.Schema.JsonSchemaExtensions.Validate(schema, m));
+
+                var serializer = new VJson.JsonSerializer(m.GetType());
+                var jsonOfM = serializer.Serialize(m);
+                Assert.AreEqual(@"{""name"":""mesh"",""primitives"":[{""attributes"":{""POSITION"":0},""mode"":4}]}", jsonOfM);
+            }
         }
 
         [Test]
@@ -554,6 +577,19 @@ namespace UniGLTF
             };
             var json2 = JsonSchema.FromType<glTFAssets>().Serialize(model, c);
             Assert.AreEqual(@"{""version"":""0.49""}", json2);
+
+            // New models
+            {
+                var m = new VGltf.Types.Asset {
+                    Version = "0.49",
+                };
+                var schema = VJson.Schema.JsonSchemaAttribute.CreateFromType(m.GetType());
+                Assert.Null(VJson.Schema.JsonSchemaExtensions.Validate(schema, m));
+
+                var serializer = new VJson.JsonSerializer(m.GetType());
+                var jsonOfM = serializer.Serialize(m);
+                Assert.AreEqual(json2, jsonOfM);
+            }
         }
 
         [Test]

--- a/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/ImporterContext.cs
@@ -253,8 +253,14 @@ namespace UniGLTF
         [Obsolete]
         public void ParseJson(string json, IStorage storage)
         {
+            ParseJson(json); // Discard storage...
+        }
+
+        [Obsolete]
+        public void ParseJson(string json, VGltf.Glb.StoredBuffer buffer = null)
+        {
             var bytes = Encoding.UTF8.GetBytes(json);
-            ParseAsGltf(bytes, new VGltf.ResourceLoaderFromEmbedOnly()); // Ignore storage...
+            ParseAsGltf(bytes, new VGltf.ResourceLoaderFromEmbedOnly(), buffer);
         }
 
         /// <summary>
@@ -267,21 +273,21 @@ namespace UniGLTF
             ParseAsGlb(bytes);
         }
 
-        public void ParseAsGltf(string path, Stream s)
+        public void ParseAsGltf(string path, Stream s, VGltf.Glb.StoredBuffer buffer = null)
         {
             var loader = new VGltf.ResourceLoaderFromFileStorage(Path.GetDirectoryName(path));
-            ParseAsGltf(s, loader);
+            ParseAsGltf(s, loader, buffer);
         }
 
-        public void ParseAsGltf(byte[] bytes, VGltf.IResourceLoader loader)
+        public void ParseAsGltf(byte[] bytes, VGltf.IResourceLoader loader, VGltf.Glb.StoredBuffer buffer = null)
         {
             using(var s = new MemoryStream(bytes))
             {
-                ParseAsGltf(s, loader);
+                ParseAsGltf(s, loader, buffer);
             }
         }
 
-        public void ParseAsGltf(Stream ss, VGltf.IResourceLoader loader)
+        public void ParseAsGltf(Stream ss, VGltf.IResourceLoader loader, VGltf.Glb.StoredBuffer buffer = null)
         {
             // TODO: Remove Json string loader
             var bytes = new byte[ss.Length];
@@ -291,7 +297,7 @@ namespace UniGLTF
 
             using(var s = new MemoryStream(bytes))
             {
-                var c = VGltf.GltfContainer.FromGltf(s);
+                var c = VGltf.GltfContainer.FromGltf(s, buffer);
                 SetupGltf(c, loader);
             }
         }

--- a/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/MaterialImporter.cs
@@ -249,7 +249,7 @@ namespace UniGLTF
                     material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
                     material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.Zero);
                     material.SetInt("_ZWrite", 1);
-                    material.SetFloat("_Cutoff", x.alphaCutoff);
+                    material.SetFloat("_Cutoff", x.AlphaCutoff);
                     material.EnableKeyword("_ALPHATEST_ON");
                     material.DisableKeyword("_ALPHABLEND_ON");
                     material.DisableKeyword("_ALPHAPREMULTIPLY_ON");

--- a/Assets/VRM/UniGLTF/Scripts/IO/ShaderStore.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/ShaderStore.cs
@@ -1,11 +1,12 @@
 ﻿using UnityEngine;
-
+using System.Collections.Generic;
 
 namespace UniGLTF
 {
     public interface IShaderStore
     {
         Shader GetShader(glTFMaterial material);
+        Shader GetShader(VGltf.Types.Material material);
     }
 
     public class ShaderStore : IShaderStore
@@ -112,6 +113,23 @@ namespace UniGLTF
             }
 
             if (material.extensions != null && material.extensions.KHR_materials_unlit != null)
+            {
+                return UniUnlit;
+            }
+
+            // standard
+            return Default;
+        }
+
+        public Shader GetShader(VGltf.Types.Material material)
+        {
+            if (material == null)
+            {
+                return Default;
+            }
+
+            var extensions = material.Extensions as Dictionary<string, object>;
+            if (extensions != null && extensions.ContainsKey("KHR_materials_unlit"))
             {
                 return UniUnlit;
             }

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureIO.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureIO.cs
@@ -59,6 +59,40 @@ namespace UniGLTF
             return glTFTextureTypes.Unknown;
         }
 
+        public static glTFTextureTypes GetglTFTextureType(VGltf.Types.Gltf gltf, int textureIndex)
+        {
+            if (gltf.Materials == null) {
+                return glTFTextureTypes.Unknown;
+            }
+
+            foreach (var material in gltf.Materials)
+            {
+                var textureInfo = VGltf.Types.MaterialExtensions.GetTextures(material).FirstOrDefault(x => (x!=null) && x.Index == textureIndex);
+                if (textureInfo != null)
+                {
+                    switch(textureInfo.Kind)
+                    {
+                        case VGltf.Types.TextureInfoKind.BaseColor:
+                            return glTFTextureTypes.BaseColor;
+
+                        case VGltf.Types.TextureInfoKind.MetallicRoughness:
+                            return glTFTextureTypes.Metallic;
+
+                        case VGltf.Types.TextureInfoKind.Normal:
+                            return glTFTextureTypes.Normal;
+
+                        case VGltf.Types.TextureInfoKind.Occlusion:
+                            return glTFTextureTypes.Occlusion;
+
+                        case VGltf.Types.TextureInfoKind.Emissive:
+                            return glTFTextureTypes.Emissive;
+                    }
+                }
+            }
+
+            return glTFTextureTypes.Unknown;
+        }
+
 #if UNITY_EDITOR
         public static void MarkTextureAssetAsNormalMap(string assetPath)
         {
@@ -129,7 +163,7 @@ namespace UniGLTF
                         Bytes = System.IO.File.ReadAllBytes(path.FullPath),
                         Mime = "image/png",
                     };
-                }                    
+                }
             }
 #endif
 

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
@@ -138,21 +138,21 @@ namespace UniGLTF
         #region Process
         ITextureLoader m_textureLoader;
 
-        public void Process(VGltf.ResourcesStore store, IStorage storage)
+        public void Process(VGltf.ResourcesStore store)
         {
-            ProcessOnAnyThread(store, storage);
+            ProcessOnAnyThread(store);
             ProcessOnMainThreadCoroutine(store).CoroutinetoEnd();
         }
 
-        public IEnumerator ProcessCoroutine(VGltf.ResourcesStore store, IStorage storage)
+        public IEnumerator ProcessCoroutine(VGltf.ResourcesStore store)
         {
-            ProcessOnAnyThread(store, storage);
+            ProcessOnAnyThread(store);
             yield return ProcessOnMainThreadCoroutine(store);
         }
 
-        public void ProcessOnAnyThread(VGltf.ResourcesStore store, IStorage storage)
+        public void ProcessOnAnyThread(VGltf.ResourcesStore store)
         {
-            m_textureLoader.ProcessOnAnyThread(store, storage);
+            m_textureLoader.ProcessOnAnyThread(store);
         }
 
         public IEnumerator ProcessOnMainThreadCoroutine(VGltf.ResourcesStore store)

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureItem.cs
@@ -138,32 +138,36 @@ namespace UniGLTF
         #region Process
         ITextureLoader m_textureLoader;
 
-        public void Process(glTF gltf, IStorage storage)
+        public void Process(VGltf.ResourcesStore store, IStorage storage)
         {
-            ProcessOnAnyThread(gltf, storage);
-            ProcessOnMainThreadCoroutine(gltf).CoroutinetoEnd();
+            ProcessOnAnyThread(store, storage);
+            ProcessOnMainThreadCoroutine(store).CoroutinetoEnd();
         }
 
-        public IEnumerator ProcessCoroutine(glTF gltf, IStorage storage)
+        public IEnumerator ProcessCoroutine(VGltf.ResourcesStore store, IStorage storage)
         {
-            ProcessOnAnyThread(gltf, storage);
-            yield return ProcessOnMainThreadCoroutine(gltf);
+            ProcessOnAnyThread(store, storage);
+            yield return ProcessOnMainThreadCoroutine(store);
         }
 
-        public void ProcessOnAnyThread(glTF gltf, IStorage storage)
+        public void ProcessOnAnyThread(VGltf.ResourcesStore store, IStorage storage)
         {
-            m_textureLoader.ProcessOnAnyThread(gltf, storage);
+            m_textureLoader.ProcessOnAnyThread(store, storage);
         }
 
-        public IEnumerator ProcessOnMainThreadCoroutine(glTF gltf)
+        public IEnumerator ProcessOnMainThreadCoroutine(VGltf.ResourcesStore store)
         {
+            var gltf = store.Gltf;
+
             using (m_textureLoader)
             {
                 var textureType = TextureIO.GetglTFTextureType(gltf, m_textureIndex);
                 var colorSpace = TextureIO.GetColorSpace(textureType);
                 var isLinear = colorSpace == RenderTextureReadWrite.Linear;
                 yield return m_textureLoader.ProcessOnMainThread(isLinear);
-                TextureSamplerUtil.SetSampler(Texture, gltf.GetSamplerFromTextureIndex(m_textureIndex));
+
+                var sampler = VGltf.Types.GltfExtensions.GetSamplerByTextureIndex(gltf, m_textureIndex);
+                TextureSamplerUtil.SetSampler(Texture, sampler);
             }
         }
         #endregion

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureLoader.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureLoader.cs
@@ -19,7 +19,7 @@ namespace UniGLTF
         /// </summary>
         /// <param name="gltf"></param>
         /// <param name="storage"></param>
-        void ProcessOnAnyThread(VGltf.ResourcesStore store, IStorage storage);
+        void ProcessOnAnyThread(VGltf.ResourcesStore store);
 
         /// <summary>
         /// Call from unity main thread
@@ -49,7 +49,7 @@ namespace UniGLTF
         {
         }
 
-        public void ProcessOnAnyThread(VGltf.ResourcesStore store, IStorage storage)
+        public void ProcessOnAnyThread(VGltf.ResourcesStore store)
         {
         }
 
@@ -117,7 +117,7 @@ namespace UniGLTF
 
         Byte[] m_imageBytes;
         string m_textureName;
-        public void ProcessOnAnyThread(VGltf.ResourcesStore store, IStorage storage)
+        public void ProcessOnAnyThread(VGltf.ResourcesStore store)
         {
             var texture = store.Gltf.Textures[m_textureIndex];
             var imageIndex = texture.Source.Value;
@@ -172,7 +172,7 @@ namespace UniGLTF
 
         ArraySegment<Byte> m_segments;
         string m_textureName;
-        public void ProcessOnAnyThread(VGltf.ResourcesStore store, IStorage storage)
+        public void ProcessOnAnyThread(VGltf.ResourcesStore store)
         {
             var texture = store.Gltf.Textures[m_textureIndex];
             var imageIndex = texture.Source.Value;

--- a/Assets/VRM/UniGLTF/Scripts/IO/TextureSamplerUtil.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TextureSamplerUtil.cs
@@ -23,128 +23,103 @@ namespace UniGLTF
             return new KeyValuePair<TextureWrapType, TextureWrapMode>(type, mode);
         }
 
-        public static IEnumerable<KeyValuePair<TextureWrapType, TextureWrapMode>> GetUnityWrapMode(glTFTextureSampler sampler)
+        public static IEnumerable<KeyValuePair<TextureWrapType, TextureWrapMode>> GetUnityWrapMode(VGltf.Types.Sampler sampler)
         {
 #if UNITY_2017_1_OR_NEWER
-            if (sampler.wrapS == sampler.wrapT)
+            if (sampler.WrapS == sampler.WrapT)
             {
-                switch (sampler.wrapS)
+                switch (sampler.WrapS)
                 {
-                    case glWrap.NONE: // default
-                        yield return TypeWithMode(TextureWrapType.All, TextureWrapMode.Repeat);
-                        break;
-
-                    case glWrap.CLAMP_TO_EDGE:
+                    case VGltf.Types.Sampler.WrapEnum.ClampToEdge:
                         yield return TypeWithMode(TextureWrapType.All, TextureWrapMode.Clamp);
                         break;
 
-                    case glWrap.REPEAT:
-                        yield return TypeWithMode(TextureWrapType.All, TextureWrapMode.Repeat);
-                        break;
-
-                    case glWrap.MIRRORED_REPEAT:
+                    case VGltf.Types.Sampler.WrapEnum.MirroredRepeat:
                         yield return TypeWithMode(TextureWrapType.All, TextureWrapMode.Mirror);
                         break;
 
+                    case VGltf.Types.Sampler.WrapEnum.Repeat:
                     default:
-                        throw new NotImplementedException();
+                        yield return TypeWithMode(TextureWrapType.All, TextureWrapMode.Repeat);
+                        break;
                 }
             }
             else
             {
-                switch (sampler.wrapS)
+                switch (sampler.WrapS)
                 {
-                    case glWrap.NONE: // default
-                        yield return TypeWithMode(TextureWrapType.U, TextureWrapMode.Repeat);
-                        break;
-
-                    case glWrap.CLAMP_TO_EDGE:
+                    case VGltf.Types.Sampler.WrapEnum.ClampToEdge:
                         yield return TypeWithMode(TextureWrapType.U, TextureWrapMode.Clamp);
                         break;
 
-                    case glWrap.REPEAT:
-                        yield return TypeWithMode(TextureWrapType.U, TextureWrapMode.Repeat);
-                        break;
-
-                    case glWrap.MIRRORED_REPEAT:
+                    case VGltf.Types.Sampler.WrapEnum.MirroredRepeat:
                         yield return TypeWithMode(TextureWrapType.U, TextureWrapMode.Mirror);
                         break;
 
+                    case VGltf.Types.Sampler.WrapEnum.Repeat:
                     default:
-                        throw new NotImplementedException();
-                }
-                switch (sampler.wrapT)
-                {
-                    case glWrap.NONE: // default
-                        yield return TypeWithMode(TextureWrapType.V, TextureWrapMode.Repeat);
+                        yield return TypeWithMode(TextureWrapType.U, TextureWrapMode.Repeat);
                         break;
-
-                    case glWrap.CLAMP_TO_EDGE:
+                }
+                switch (sampler.WrapT)
+                {
+                    case VGltf.Types.Sampler.WrapEnum.ClampToEdge:
                         yield return TypeWithMode(TextureWrapType.V, TextureWrapMode.Clamp);
                         break;
 
-                    case glWrap.REPEAT:
-                        yield return TypeWithMode(TextureWrapType.V, TextureWrapMode.Repeat);
-                        break;
-
-                    case glWrap.MIRRORED_REPEAT:
+                    case VGltf.Types.Sampler.WrapEnum.MirroredRepeat:
                         yield return TypeWithMode(TextureWrapType.V, TextureWrapMode.Mirror);
                         break;
 
+                    case VGltf.Types.Sampler.WrapEnum.Repeat:
                     default:
-                        throw new NotImplementedException();
+                        yield return TypeWithMode(TextureWrapType.V, TextureWrapMode.Repeat);
+                        break;
                 }
 #else
             // Unity2017.1より前
             // * wrapSとwrapTの区別が無くてwrapしかない
             // * Mirrorが無い
 
-            switch (sampler.wrapS)
+            switch (sampler.WrapS)
             {
-                case glWrap.NONE: // default
-                    yield return TypeWithMode(TextureWrapType.All, TextureWrapMode.Repeat);
-                    break;
-
-                case glWrap.CLAMP_TO_EDGE:
-                case glWrap.MIRRORED_REPEAT:
+                case VGltf.Types.Sampler.WrapEnum.ClampToEdge:
+                case VGltf.Types.Sampler.WrapEnum.MirroredRepeat:
                     yield return TypeWithMode(TextureWrapType.All, TextureWrapMode.Clamp);
                     break;
 
-                case glWrap.REPEAT:
+                case VGltf.Types.Sampler.WrapEnum.Repeat:
+                default:
                     yield return TypeWithMode(TextureWrapType.All, TextureWrapMode.Repeat);
                     break;
-
-                default:
-                    throw new NotImplementedException();
 #endif
             }
         }
         #endregion
 
-        public static FilterMode ImportFilterMode(glFilter filterMode)
+        public static FilterMode ImportFilterMode(VGltf.Types.Sampler.MinFilterEnum filterMode)
         {
             switch (filterMode)
             {
-                case glFilter.NEAREST:
-                case glFilter.NEAREST_MIPMAP_LINEAR:
-                case glFilter.NEAREST_MIPMAP_NEAREST:
+                case VGltf.Types.Sampler.MinFilterEnum.NEAREST:
+                case VGltf.Types.Sampler.MinFilterEnum.NEAREST_MIPMAP_NEAREST:
+                case VGltf.Types.Sampler.MinFilterEnum.NEAREST_MIPMAP_LINEAR:
                     return FilterMode.Point;
 
-                case glFilter.NONE:
-                case glFilter.LINEAR:
-                case glFilter.LINEAR_MIPMAP_NEAREST:
+
+                case VGltf.Types.Sampler.MinFilterEnum.LINEAR:
+                case VGltf.Types.Sampler.MinFilterEnum.LINEAR_MIPMAP_NEAREST:
                     return FilterMode.Bilinear;
 
-                case glFilter.LINEAR_MIPMAP_LINEAR:
+                case VGltf.Types.Sampler.MinFilterEnum.LINEAR_MIPMAP_LINEAR:
                     return FilterMode.Trilinear;
 
                 default:
                     throw new NotImplementedException();
-
             }
         }
 
-        public static void SetSampler(Texture2D texture, glTFTextureSampler sampler)
+        public static void SetSampler(Texture2D texture, VGltf.Types.Sampler sampler)
         {
             if (texture == null)
             {
@@ -178,7 +153,7 @@ namespace UniGLTF
                 }
             }
 
-            texture.filterMode = ImportFilterMode(sampler.minFilter);
+            texture.filterMode = ImportFilterMode(sampler.MinFilter);
         }
 
         #region Export

--- a/Assets/VRM/UniGLTF/Scripts/IO/TriangleUtil.cs
+++ b/Assets/VRM/UniGLTF/Scripts/IO/TriangleUtil.cs
@@ -22,30 +22,32 @@ public static class TriangleUtil
 
     public static IEnumerable<int> FlipTriangle(IEnumerable<Int32> src)
     {
-        var it = src.GetEnumerator();
-        while (true)
+        using(var it = src.GetEnumerator())
         {
-            if (!it.MoveNext())
+            while (true)
             {
-                yield break;
-            }
-            var i0 = it.Current;
+                if (!it.MoveNext())
+                {
+                    yield break;
+                }
+                var i0 = it.Current;
 
-            if (!it.MoveNext())
-            {
-                yield break;
-            }
-            var i1 = it.Current;
+                if (!it.MoveNext())
+                {
+                    yield break;
+                }
+                var i1 = it.Current;
 
-            if (!it.MoveNext())
-            {
-                yield break;
-            }
-            var i2 = it.Current;
+                if (!it.MoveNext())
+                {
+                    yield break;
+                }
+                var i2 = it.Current;
 
-            yield return i2;
-            yield return i1;
-            yield return i0;
+                yield return i2;
+                yield return i1;
+                yield return i0;
+            }
         }
     }
 }

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMImporter.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMImporter.cs
@@ -15,8 +15,7 @@ namespace VRM
         public static GameObject LoadFromPath(string path)
         {
             var context = new VRMImporterContext();
-            context.Parse(path, File.ReadAllBytes(path));
-            context.Load();
+            context.Load(path);
             context.ShowMeshes();
             context.EnableUpdateWhenOffscreen();
             return context.Root;
@@ -27,6 +26,11 @@ namespace VRM
         {
             var context = new VRMImporterContext();
             context.ParseGlb(bytes);
+            using(var s = new MemoryStream(bytes))
+            {
+                var c = VGltf.GltfContainer.FromGlb(s);
+                context.SetupGltf(c, null);
+            }
             context.Load();
             context.ShowMeshes();
             context.EnableUpdateWhenOffscreen();
@@ -63,7 +67,7 @@ namespace VRM
                     context.ShowMeshes();
                 }
                 onLoaded(context.Root);
-            }, 
+            },
             onError);
         }
 

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMImporterContext.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMImporterContext.cs
@@ -32,9 +32,8 @@ namespace VRM
             }
         }
 
-        public override void ParseJson(string json, IStorage storage)
+        public override void AfterSetupHook()
         {
-            base.ParseJson(json, storage);
             SetMaterialImporter(new VRMMaterialImporter(this, glTF_VRM_Material.Parse(Json)));
         }
 
@@ -301,7 +300,7 @@ namespace VRM
                 if (gltfMeta.texture >= 0 && gltfMeta.texture < GLTF.textures.Count)
                 {
                     var t = new TextureItem(gltfMeta.texture);
-                    t.Process(GLTF, Storage);
+                    t.Process(Store, Storage);
                     meta.Thumbnail = t.Texture;
                 }
             }

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMImporterContext.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMImporterContext.cs
@@ -300,7 +300,7 @@ namespace VRM
                 if (gltfMeta.texture >= 0 && gltfMeta.texture < GLTF.textures.Count)
                 {
                     var t = new TextureItem(gltfMeta.texture);
-                    t.Process(Store, Storage);
+                    t.Process(Store);
                     meta.Thumbnail = t.Texture;
                 }
             }

--- a/Assets/VRM/UniVRM/Scripts/Format/VRMMaterialImporter.cs
+++ b/Assets/VRM/UniVRM/Scripts/Format/VRMMaterialImporter.cs
@@ -26,7 +26,7 @@ namespace VRM
             "VRM/UnlitTransparentZWrite",
         };
 
-        public override Material CreateMaterial(int i, glTFMaterial src)
+        public override Material CreateMaterial(int i, VGltf.Types.Material src)
         {
             if(i==0 && m_materials.Count == 0)
             {

--- a/Assets/VRM/VRM.asmdef
+++ b/Assets/VRM/VRM.asmdef
@@ -6,7 +6,9 @@
         "UniUnlit",
         "UniHumanoid",
         "UniJSON",
-        "ShaderProperty.Runtime"
+        "ShaderProperty.Runtime",
+        "VJson",
+        "VGltf"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],


### PR DESCRIPTION
**(WIP) This PR contains many breaking changes!**

## Changes (後で訳す)

ファイルフォーマットに関する入出力を新規に開発したライブラリで置き換えます．

## Motivation (後で訳す)
 
glTFやVRMのファイルの入出力周りもUnity上での動作確認が前提になっており，CIによるテストが少々やりにくいところがあると考えています．そこで，新規にpure C#なライブラリとして開発したライブラリでファイルの入出力まわりを置き換える実装を試験的に行います．

この新規ライブラリが目指すものは以下です．

- pure C#製でUnityの依存なしで開発ができる
  - CLIで高速なイテレーションを回せる
  - CIによる自動テストでの品質の向上
    - 規格に整合しているか
    - ファイル形式の互換性の担保
    - 様々なランタイムでのテスト
      - .NET 3.5
      - .NET 4.5
      - .NET Standard 1.6 (UWP環境など)
      - IL2CPP (TODO) 
      - Unity play mode test (TODO) 
- .NET Standard 1.6対応によるサポートするプラットフォームの拡充

導入ライブラリは以下 (個人リポジトリから共有なものに移す予定です)

- https://github.com/yutopp/VJson
- https://github.com/yutopp/VGltf
- https://github.com/yutopp/VVrm

このPRでは，上記の目標に加えて，

- 新規ライブラリの互換性維持能力 (デグレしにくさ)
- 性能

なども検証できたらと考えています．

## Plan to release (後で訳す)

- このPR上で開発を進めていく
- 変更は本流にマージせずにunitypackageをリリースして動作確認を進める
- 過去のモデルとの互換性などを確認しつつ安定してきたら本流にマージ

## TODO

- [ ] Formats
  - [ ] glTF
    - [ ] Loading
    - [ ] Saving
  - [ ] VRM
    - [ ] Loading
    - [ ] Saving
- [ ] Testing
- [ ] Other
  - [ ] Bump version of deps